### PR TITLE
Use exclude list defaults for both page render and admin settings

### DIFF
--- a/page-optimize.php
+++ b/page-optimize.php
@@ -61,7 +61,7 @@ function page_optimize_js_exclude_list() {
 		return [];
 	}
 
-	return explode( ',', $exclude_string );
+	return explode( ',', $exclude_list );
 }
 
 function page_optimize_js_exclude_list_default() {
@@ -79,7 +79,7 @@ function page_optimize_css_exclude_list() {
 		return [];
 	}
 
-	return explode( ',', $exclude_string );
+	return explode( ',', $exclude_list );
 }
 
 function page_optimize_css_exclude_list_default() {

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -83,7 +83,7 @@ function page_optimize_css_exclude_list() {
 }
 
 function page_optimize_css_exclude_list_default() {
-	// WordPress core stuff, a lot of other plugins depend on it.
+	// WordPress core stuff
 	return [ 'admin-bar', 'dashicons' ];
 }
 

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -54,19 +54,29 @@ function page_optimize_should_concat_css() {
 function page_optimize_js_exclude_list() {
 	$exclude_string = get_option( 'page_optimize-js-exclude' );
 	if ( empty( $exclude_string ) ) {
-		return [];
+		return page_optimize_js_exclude_list_default();
 	}
 
 	return explode( ',', $exclude_string );
 }
 
+function page_optimize_js_exclude_list_default() {
+	// WordPress core stuff, a lot of other plugins depend on it.
+	return [ 'jquery', 'underscore', 'backbone' ];
+}
+
 function page_optimize_css_exclude_list() {
 	$exclude_string = get_option( 'page_optimize-css-exclude' );
 	if ( empty( $exclude_string ) ) {
-		return [];
+		return page_optimize_css_exclude_list_default();
 	}
 
 	return explode( ',', $exclude_string );
+}
+
+function page_optimize_css_exclude_list_default() {
+	// WordPress core stuff, a lot of other plugins depend on it.
+	return [ 'admin-bar', 'dashicons' ];
 }
 
 function page_optimize_sanitize_js_load_mode( $value ) {

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -52,9 +52,13 @@ function page_optimize_should_concat_css() {
 }
 
 function page_optimize_js_exclude_list() {
-	$exclude_string = get_option( 'page_optimize-js-exclude' );
-	if ( empty( $exclude_string ) ) {
+	$exclude_list = get_option( 'page_optimize-js-exclude' );
+	if ( false === $exclude_list ) {
+		// Use the default since the option is not set
 		return page_optimize_js_exclude_list_default();
+	}
+	if ( '' === $exclude_list ) {
+		return [];
 	}
 
 	return explode( ',', $exclude_string );
@@ -66,9 +70,13 @@ function page_optimize_js_exclude_list_default() {
 }
 
 function page_optimize_css_exclude_list() {
-	$exclude_string = get_option( 'page_optimize-css-exclude' );
-	if ( empty( $exclude_string ) ) {
+	$exclude_list = get_option( 'page_optimize-css-exclude' );
+	if ( false === $exclude_list ) {
+		// Use the default since the option is not set
 		return page_optimize_css_exclude_list_default();
+	}
+	if ( '' === $exclude_list ) {
+		return [];
 	}
 
 	return explode( ',', $exclude_string );

--- a/settings.php
+++ b/settings.php
@@ -122,7 +122,7 @@ function page_optimize_settings_init() {
 		array(
 			'description' => __( 'Comma separated list of strings to exclude from JS concating', page_optimize_get_text_domain() ),
 			'type' => 'string',
-			'default' => 'jquery,underscore,backbone', // WordPress core stuff, a lot of other plugins depend on it.
+			'default' => implode( ',', page_optimize_js_exclude_list_default() ),
 			'sanitize_callback' => 'page_optimize_sanitize_exclude_field',
 		)
 	);
@@ -141,7 +141,7 @@ function page_optimize_settings_init() {
 		array(
 			'description' => __( 'Comma separated list of strings to exclude from CSS concating', page_optimize_get_text_domain() ),
 			'type' => 'string',
-			'default' => 'admin-bar,dashicons', // WordPress core stuff, a lot of other plugins depend on it.
+			'default' => implode( ',', page_optimize_css_exclude_list_default() ),
 			'sanitize_callback' => 'page_optimize_sanitize_exclude_field',
 		)
 	);


### PR DESCRIPTION
When the JS and CSS concat exclude list options have not been saved, saving the settings with the default exclude list does not actually add options containing the default exclude lists. This may be because the saved values match the settings' declared default values.

It seems fine for us not to save the defaults, but when rendering pages, we are not applying the defaults. This PR fixes the plugin to fall back to the default exclude lists.