### PR TITLE
Add default options on activation.

### DIFF
--- a/concat-css.php
+++ b/concat-css.php
@@ -106,7 +106,7 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 			// Skip concating CSS from exclusion list
 			$exclude_list = page_optimize_css_exclude_list();
 			foreach ( $exclude_list as $exclude ) {
-				if ( $do_concat && false !== strpos( $handle, $exclude ) ) {
+				if ( $do_concat && $handle === $exclude ) {
 					$do_concat = false;
 					if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 						echo sprintf( "\n<!-- No Concat CSS %s => Excluded option -->\n", esc_html( $handle ) );

--- a/concat-css.php
+++ b/concat-css.php
@@ -161,7 +161,7 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 						return $path;
 					}, $css );
 					$mtime = max( array_map( 'filemtime', $paths ) );
-					$path_str = implode( $css, ',' ) . "?m={$mtime}";
+					$path_str = implode( ',', $css ) . "?m={$mtime}";
 
 					if ( $this->allow_gzip_compression ) {
 						$path_64 = base64_encode( gzcompress( $path_str ) );

--- a/concat-js.php
+++ b/concat-js.php
@@ -217,7 +217,7 @@ class Page_Optimize_JS_Concat extends WP_Scripts {
 						return $path;
 					}, $js_array['paths'] );
 					$mtime = max( array_map( 'filemtime', $paths ) );
-					$path_str = implode( $js_array['paths'], ',' ) . "?m=${mtime}j";
+					$path_str = implode( ',', $js_array['paths'] ) . "?m=${mtime}j";
 
 					if ( $this->allow_gzip_compression ) {
 						$path_64 = base64_encode( gzcompress( $path_str ) );

--- a/concat-js.php
+++ b/concat-js.php
@@ -144,7 +144,7 @@ class Page_Optimize_JS_Concat extends WP_Scripts {
 			// Skip concating scripts from exclusion list
 			$exclude_list = page_optimize_js_exclude_list();
 			foreach ( $exclude_list as $exclude ) {
-				if ( $do_concat && false !== strpos( $handle, $exclude ) ) {
+				if ( $do_concat && $handle === $exclude ) {
 					$do_concat = false;
 					if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 						echo sprintf( "\n<!-- No Concat JS %s => Excluded option -->\n", esc_html( $handle ) );

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -82,7 +82,7 @@ function page_optimize_js_exclude_list() {
 
 function page_optimize_js_exclude_list_default() {
 	// WordPress core stuff, a lot of other plugins depend on it.
-	return [ 'jquery', 'underscore', 'backbone' ];
+	return [ 'jquery', 'jquery-core', 'underscore', 'backbone' ];
 }
 
 function page_optimize_css_exclude_list() {

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -31,7 +31,7 @@ function page_optimize_should_concat_js() {
 		return $_GET['concat-js'] !== '0';
 	}
 
-	return !! get_option( 'page_optimize-js', true );
+	return !! get_option( 'page_optimize-js', page_optimize_js_default() );
 }
 
 // TODO: Support JS load mode regardless of whether concat is enabled
@@ -40,7 +40,7 @@ function page_optimize_load_mode_js() {
 	if ( ! empty( $_GET['load-mode-js'] ) ) {
 		$load_mode = page_optimize_sanitize_js_load_mode( $_GET['load-mode-js'] );
 	} else {
-		$load_mode = page_optimize_sanitize_js_load_mode( get_option( 'page_optimize-load-mode', 'defer' ) );
+		$load_mode = page_optimize_sanitize_js_load_mode( get_option( 'page_optimize-load-mode', page_optimize_js_load_mode_default() ) );
 	}
 
 	return $load_mode;
@@ -52,7 +52,19 @@ function page_optimize_should_concat_css() {
 		return $_GET['concat-css'] !== '0';
 	}
 
-	return !! get_option( 'page_optimize-css', true );
+	return !! get_option( 'page_optimize-css', page_optimize_css_default() );
+}
+
+function page_optimize_js_default() {
+	return true;
+}
+
+function page_optimize_css_default() {
+	return true;
+}
+
+function page_optimize_js_load_mode_default() {
+	return 'defer';
 }
 
 function page_optimize_js_exclude_list() {

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -4,13 +4,22 @@ Plugin Name: Page Optimize
 Plugin URI: https://wordpress.org/plugins/page-optimize/
 Description: Optimizes JS and CSS for faster page load and render in the browser.
 Author: Automattic
-Version: 0.1.0
+Version: 0.1.1
 Author URI: http://automattic.com/
 */
 
 // TODO: Allow overriding with an option
 // Default cache directory
 define( 'PAGE_OPTIMIZE_CACHE_DIR', WP_CONTENT_DIR . '/cache/page_optimize' );
+
+function page_optimize_activate() {
+	update_option( 'page_optimize-js', true );
+	update_option( 'page_optimize-js-exclude', page_optimize_js_exclude_list() );
+	update_option( 'page_optimize-load-mode', 'defer' );
+	update_option( 'page_optimize-css', true );
+	update_option( 'page_optimize-css-exclude', page_optimize_css_exclude_list() );
+}
+register_activation_hook( __FILE__, 'page_optimize_activate' );
 
 // TODO: Copy tests from nginx-http-concat and/or write them
 

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -12,15 +12,6 @@ Author URI: http://automattic.com/
 // Default cache directory
 define( 'PAGE_OPTIMIZE_CACHE_DIR', WP_CONTENT_DIR . '/cache/page_optimize' );
 
-function page_optimize_activate() {
-	update_option( 'page_optimize-js', true );
-	update_option( 'page_optimize-js-exclude', page_optimize_js_exclude_list() );
-	update_option( 'page_optimize-load-mode', 'defer' );
-	update_option( 'page_optimize-css', true );
-	update_option( 'page_optimize-css-exclude', page_optimize_css_exclude_list() );
-}
-register_activation_hook( __FILE__, 'page_optimize_activate' );
-
 // TODO: Copy tests from nginx-http-concat and/or write them
 
 // TODO: Make concat URL dir configurable
@@ -40,7 +31,7 @@ function page_optimize_should_concat_js() {
 		return $_GET['concat-js'] !== '0';
 	}
 
-	return !! get_option( 'page_optimize-js' );
+	return !! get_option( 'page_optimize-js', true );
 }
 
 // TODO: Support JS load mode regardless of whether concat is enabled
@@ -49,7 +40,7 @@ function page_optimize_load_mode_js() {
 	if ( ! empty( $_GET['load-mode-js'] ) ) {
 		$load_mode = page_optimize_sanitize_js_load_mode( $_GET['load-mode-js'] );
 	} else {
-		$load_mode = page_optimize_sanitize_js_load_mode( get_option( 'page_optimize-load-mode' ) );
+		$load_mode = page_optimize_sanitize_js_load_mode( get_option( 'page_optimize-load-mode', 'defer' ) );
 	}
 
 	return $load_mode;
@@ -61,7 +52,7 @@ function page_optimize_should_concat_css() {
 		return $_GET['concat-css'] !== '0';
 	}
 
-	return !! get_option( 'page_optimize-css' );
+	return !! get_option( 'page_optimize-css', true );
 }
 
 function page_optimize_js_exclude_list() {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: performance
 Requires at least: 5.3
 Tested up to: 5.3
 Requires PHP: 7.2
-Stable tag: 0.1.0
+Stable tag: 0.1.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -31,4 +31,3 @@ Supported query params:
 * `concat-css` controls CSS concatenation. Values: `1` for ON and `0` for OFF.
 * `concat-js` controls JavaScript concatenation. Values: `1` for ON and `0` for OFF.
 * `load-mode-js` controls how non-critical JavaScript are loaded. Values: 'defer' for [deferred](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-defer), 'async' for [async loading](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-async), any other value indicates the feature should be disabled.
-

--- a/settings.php
+++ b/settings.php
@@ -111,7 +111,7 @@ function page_optimize_settings_init() {
 		array(
 			'description' => __( 'JavaScript concatenation', page_optimize_get_text_domain() ),
 			'type' => 'boolean',
-			'default' => true,
+			'default' => page_optimize_js_default(),
 		)
 	);
 	register_setting(
@@ -120,7 +120,7 @@ function page_optimize_settings_init() {
 		array(
 			'description' => __( 'Non-critical script execution mode', page_optimize_get_text_domain() ),
 			'type' => 'string',
-			'default' => 'defer',
+			'default' => page_optimize_js_load_mode_default(),
 			'sanitize_callback' => 'page_optimize_sanitize_js_load_mode',
 		)
 	);
@@ -140,7 +140,7 @@ function page_optimize_settings_init() {
 		array(
 			'description' => __( 'CSS concatenation', page_optimize_get_text_domain() ),
 			'type' => 'boolean',
-			'default' => true,
+			'default' => page_optimize_css_default(),
 		)
 	);
 	register_setting(

--- a/settings.php
+++ b/settings.php
@@ -111,7 +111,7 @@ function page_optimize_settings_init() {
 		array(
 			'description' => __( 'JavaScript concatenation', page_optimize_get_text_domain() ),
 			'type' => 'boolean',
-			'default' => false,
+			'default' => true,
 		)
 	);
 	register_setting(
@@ -120,7 +120,7 @@ function page_optimize_settings_init() {
 		array(
 			'description' => __( 'Non-critical script execution mode', page_optimize_get_text_domain() ),
 			'type' => 'string',
-			'default' => 'none',
+			'default' => 'defer',
 			'sanitize_callback' => 'page_optimize_sanitize_js_load_mode',
 		)
 	);
@@ -140,7 +140,7 @@ function page_optimize_settings_init() {
 		array(
 			'description' => __( 'CSS concatenation', page_optimize_get_text_domain() ),
 			'type' => 'boolean',
-			'default' => false,
+			'default' => true,
 		)
 	);
 	register_setting(


### PR DESCRIPTION
- Default values on activation. Wrapped in functions, so easy to change
- Exact match exclusion list, instead of finding a substring
- `implode()` was used incorrectly