### PR TITLE
Cache cleanup with WP Cron

### DIFF
--- a/page-optimize.php
+++ b/page-optimize.php
@@ -13,7 +13,7 @@ if ( ! defined( 'PAGE_OPTIMIZE_CACHE_DIR' ) ) {
 	define( 'PAGE_OPTIMIZE_CACHE_DIR', WP_CONTENT_DIR . '/cache/page_optimize' );
 }
 
-define( 'PAGE_OPTIMIZE_CRON_CACHE_CLEANUP', 'page_optimize_cron_cache_cleanup' );
+define( 'PAGE_OPTIMIZE_CRON_CACHE_CLEANUP_JOB', 'page_optimize_cron_cache_cleanup' );
 
 // TODO: Copy tests from nginx-http-concat and/or write them
 
@@ -43,13 +43,13 @@ function page_optimize_cache_cleanup( $age = DAY_IN_SECONDS ) {
 		}
 	}
 }
-add_action( PAGE_OPTIMIZE_CRON_CACHE_CLEANUP, 'page_optimize_cache_cleanup' );
+add_action( PAGE_OPTIMIZE_CRON_CACHE_CLEANUP_JOB, 'page_optimize_cache_cleanup' );
 
 // Unschedule cache cleanup, and purge cache directory
 function page_optimize_deactivate() {
 	page_optimize_cache_cleanup( 0 );
 
-	wp_clear_scheduled_hook( PAGE_OPTIMIZE_CRON_CACHE_CLEANUP );
+	wp_clear_scheduled_hook( PAGE_OPTIMIZE_CRON_CACHE_CLEANUP_JOB );
 }
 
 register_deactivation_hook( __FILE__, 'page_optimize_deactivate' );
@@ -173,8 +173,8 @@ function page_optimize_init() {
 	}
 
 	// Schedule cache cleanup on init
-	if( ! wp_next_scheduled( PAGE_OPTIMIZE_CRON_CACHE_CLEANUP ) ) {
-		wp_schedule_event( time(), 'daily', PAGE_OPTIMIZE_CRON_CACHE_CLEANUP );
+	if( ! wp_next_scheduled( PAGE_OPTIMIZE_CRON_CACHE_CLEANUP_JOB ) ) {
+		wp_schedule_event( time(), 'daily', PAGE_OPTIMIZE_CRON_CACHE_CLEANUP_JOB );
 	}
 
 	require_once __DIR__ . '/settings.php';

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -47,6 +47,21 @@ function page_optimize_cache_cleanup() {
 	}
 }
 
+// Unschedule cache cleanup, and purge cache directory
+function page_optimize_deactivate() {
+	// Purge cache dir if it exists
+	if ( is_dir( PAGE_OPTIMIZE_CACHE_DIR ) ) {
+		array_map(
+			'unlink',
+			glob( PAGE_OPTIMIZE_CACHE_DIR . '/*.*' )
+		);
+		rmdir( PAGE_OPTIMIZE_CACHE_DIR );
+	}
+
+	wp_clear_scheduled_hook( 'page_optimize_cache_cleanup' );
+}
+register_deactivation_hook( __FILE__, 'page_optimize_deactivate' );
+
 function page_optimize_get_text_domain() {
 	return 'page-optimize';
 }

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -8,9 +8,10 @@ Version: 0.1.3
 Author URI: http://automattic.com/
 */
 
-// TODO: Allow overriding with an option
 // Default cache directory
-define( 'PAGE_OPTIMIZE_CACHE_DIR', WP_CONTENT_DIR . '/cache/page_optimize' );
+if ( ! defined( 'PAGE_OPTIMIZE_CACHE_DIR' ) ) {
+	define( 'PAGE_OPTIMIZE_CACHE_DIR', WP_CONTENT_DIR . '/cache/page_optimize' );
+}
 
 // TODO: Copy tests from nginx-http-concat and/or write them
 
@@ -50,13 +51,8 @@ function page_optimize_cache_cleanup() {
 // Unschedule cache cleanup, and purge cache directory
 function page_optimize_deactivate() {
 	// Purge cache dir if it exists
-	if ( is_dir( PAGE_OPTIMIZE_CACHE_DIR ) ) {
-		array_map(
-			'unlink',
-			glob( PAGE_OPTIMIZE_CACHE_DIR . '/*.*' )
-		);
-		rmdir( PAGE_OPTIMIZE_CACHE_DIR );
-	}
+	$wp_filesystem_direct = WP_Filesystem_Direct();
+	$wp_filesystem_direct->rmdir( PAGE_OPTIMIZE_CACHE_DIR, true );
 
 	wp_clear_scheduled_hook( 'page_optimize_cache_cleanup' );
 }

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -24,7 +24,7 @@ if ( isset( $_SERVER['REQUEST_URI'] ) && '/_static/' === substr( $_SERVER['REQUE
 	exit;
 }
 
-function page_optimize_cache_cleanup( $age = DAY_IN_SECONDS ) {
+function page_optimize_cache_cleanup( $file_age = DAY_IN_SECONDS ) {
 	if ( ! is_dir( PAGE_OPTIMIZE_CACHE_DIR ) ) {
 		return;
 	}
@@ -38,7 +38,7 @@ function page_optimize_cache_cleanup( $age = DAY_IN_SECONDS ) {
 			continue;
 		}
 
-		if ( ( time() - $age ) > filemtime( $cache_file ) ) {
+		if ( ( time() - $file_age ) > filemtime( $cache_file ) ) {
 			unlink( $cache_file );
 		}
 	}
@@ -47,7 +47,7 @@ add_action( PAGE_OPTIMIZE_CRON_CACHE_CLEANUP_JOB, 'page_optimize_cache_cleanup' 
 
 // Unschedule cache cleanup, and purge cache directory
 function page_optimize_deactivate() {
-	page_optimize_cache_cleanup( 0 );
+	page_optimize_cache_cleanup( $file_age = 0 );
 
 	wp_clear_scheduled_hook( PAGE_OPTIMIZE_CRON_CACHE_CLEANUP_JOB );
 }

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -21,6 +21,32 @@ if ( isset( $_SERVER['REQUEST_URI'] ) && '/_static/' === substr( $_SERVER['REQUE
 	exit;
 }
 
+if( ! wp_next_scheduled( 'page_optimize_cache_cleanup' ) ) {
+	wp_schedule_event( time(), 'daily', 'page_optimize_cache_cleanup' );
+}
+
+function page_optimize_cache_cleanup() {
+	if ( ! is_dir( PAGE_OPTIMIZE_CACHE_DIR ) ) {
+		return;
+	}
+
+	// Grab all files in the cache directory
+	$cache_files = array_filter(
+		scandir( PAGE_OPTIMIZE_CACHE_DIR ),
+		function ( $file ) {
+			return is_file( PAGE_OPTIMIZE_CACHE_DIR . "/$file" );
+		}
+	);
+
+	// Cleanup all files older than 24 hours
+	foreach ( $cache_files as $cache_file ) {
+		$cache_file_full_path = PAGE_OPTIMIZE_CACHE_DIR . "/$cache_file";
+		if ( ( time() - DAY_IN_SECONDS ) > filemtime( $cache_file_full_path ) ) {
+			unlink( $cache_file_full_path );
+		}
+	}
+}
+
 function page_optimize_get_text_domain() {
 	return 'page-optimize';
 }

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -50,13 +50,23 @@ function page_optimize_cache_cleanup() {
 
 // Unschedule cache cleanup, and purge cache directory
 function page_optimize_deactivate() {
-	// Purge cache dir if it exists
-	$wp_filesystem_direct = WP_Filesystem_Direct();
-	$wp_filesystem_direct->rmdir( PAGE_OPTIMIZE_CACHE_DIR, true );
+	if ( is_dir( PAGE_OPTIMIZE_CACHE_DIR ) ) {
+		page_optimize_remove_directory( PAGE_OPTIMIZE_CACHE_DIR );
+	}
 
 	wp_clear_scheduled_hook( 'page_optimize_cache_cleanup' );
 }
 register_deactivation_hook( __FILE__, 'page_optimize_deactivate' );
+
+function page_optimize_remove_directory( $dir ) {
+	$files = array_diff( scandir( $dir ), array( '.', '..' ) );
+	foreach ( $files as $file ) {
+		$file_full_path = "$dir/$file";
+		( is_dir( $file_full_path ) ) ? page_optimize_remove_directory( $file_full_path ) : unlink( $file_full_path );
+	}
+
+	return rmdir( $dir );
+}
 
 function page_optimize_get_text_domain() {
 	return 'page-optimize';

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -4,7 +4,7 @@ Plugin Name: Page Optimize
 Plugin URI: https://wordpress.org/plugins/page-optimize/
 Description: Optimizes JS and CSS for faster page load and render in the browser.
 Author: Automattic
-Version: 0.1.3
+Version: 0.2.0
 Author URI: http://automattic.com/
 */
 

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -47,7 +47,7 @@ add_action( PAGE_OPTIMIZE_CRON_CACHE_CLEANUP_JOB, 'page_optimize_cache_cleanup' 
 
 // Unschedule cache cleanup, and purge cache directory
 function page_optimize_deactivate() {
-	page_optimize_cache_cleanup( $file_age = 0 );
+	page_optimize_cache_cleanup( 0 /* max file age */ );
 
 	wp_clear_scheduled_hook( PAGE_OPTIMIZE_CRON_CACHE_CLEANUP_JOB );
 }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: performance
 Requires at least: 5.3
 Tested up to: 5.3
 Requires PHP: 7.2
-Stable tag: 0.1.3
+Stable tag: 0.2.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/service.php
+++ b/service.php
@@ -29,8 +29,8 @@ function page_optimize_service_request() {
 
 	if ( $use_cache ) {
 		$request_uri_hash = md5( $_SERVER['REQUEST_URI'] );
-		$cache_file = PAGE_OPTIMIZE_CACHE_DIR . "/$request_uri_hash";
-		$cache_file_meta = PAGE_OPTIMIZE_CACHE_DIR . "/meta-$request_uri_hash";
+		$cache_file = PAGE_OPTIMIZE_CACHE_DIR . "/page-optimize-cache-$request_uri_hash";
+		$cache_file_meta = PAGE_OPTIMIZE_CACHE_DIR . "/page-optimize-cache-meta-$request_uri_hash";
 
 		if ( file_exists( $cache_file ) ) {
 			if ( isset( $_SERVER['HTTP_IF_MODIFIED_SINCE'] ) ) {

--- a/service.php
+++ b/service.php
@@ -33,39 +33,33 @@ function page_optimize_service_request() {
 		$cache_file_meta = PAGE_OPTIMIZE_CACHE_DIR . "/meta-$request_uri_hash";
 
 		if ( file_exists( $cache_file ) ) {
-			if ( ( time() - filemtime( $cache_file ) ) > 2 * 3600 ) {
-				// file older than 2 hours, delete cache.
-				// TODO: Make max age configurable or get rid of max age and just rely on mtime
-				unlink( $cache_file );
-			} else {
-				if ( isset( $_SERVER['HTTP_IF_MODIFIED_SINCE'] ) ) {
-					if ( strtotime( $_SERVER['HTTP_IF_MODIFIED_SINCE'] ) < filemtime( $cache_file ) ) {
-						header( 'HTTP/1.1 304 Not Modified' );
-						exit;
-					}
+			if ( isset( $_SERVER['HTTP_IF_MODIFIED_SINCE'] ) ) {
+				if ( strtotime( $_SERVER['HTTP_IF_MODIFIED_SINCE'] ) < filemtime( $cache_file ) ) {
+					header( 'HTTP/1.1 304 Not Modified' );
+					exit;
 				}
-
-				if ( file_exists( $cache_file_meta ) ) {
-					$meta = json_decode( file_get_contents( $cache_file_meta ) );
-					if ( null !== $meta && isset( $meta->headers ) ) {
-						foreach ( $meta->headers as $header ) {
-							header( $header );
-						}
-					}
-				}
-
-				$etag = '"' . md5( file_get_contents( $cache_file ) ) . '"';
-
-				ob_start( 'ob_gzhandler' );
-				header( 'X-Page-Optimize: cached' );
-				header( 'Cache-Control: max-age=' . 31536000 );
-				header( 'ETag: ' . $etag );
-
-				echo file_get_contents( $cache_file ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- We need to trust this unfortunately.
-				$output = ob_get_clean();
-				echo $output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- We need to trust this unfortunately.
-				die();
 			}
+
+			if ( file_exists( $cache_file_meta ) ) {
+				$meta = json_decode( file_get_contents( $cache_file_meta ) );
+				if ( null !== $meta && isset( $meta->headers ) ) {
+					foreach ( $meta->headers as $header ) {
+						header( $header );
+					}
+				}
+			}
+
+			$etag = '"' . md5( file_get_contents( $cache_file ) ) . '"';
+
+			ob_start( 'ob_gzhandler' );
+			header( 'X-Page-Optimize: cached' );
+			header( 'Cache-Control: max-age=' . 31536000 );
+			header( 'ETag: ' . $etag );
+
+			echo file_get_contents( $cache_file ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- We need to trust this unfortunately.
+			$output = ob_get_clean();
+			echo $output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- We need to trust this unfortunately.
+			die();
 		}
 	}
 


### PR DESCRIPTION
Clear cache once per day. Remove all files older
than 24 hours. They will get regenerated on next request.

No need to check inside service.php for file age. We
send the `filemtime` (which is max file mtime of the concated stuff)
as part of the request URI, which is
hashed to generate the cache file. If none of the files change,
we shouldn't do anything. 

Update naming pattern, so we can "reliably" cleanup.