### PR TITLE
Bail if we're in customizer

### DIFF
--- a/concat-js.php
+++ b/concat-js.php
@@ -217,7 +217,7 @@ class Page_Optimize_JS_Concat extends WP_Scripts {
 						return $path;
 					}, $js_array['paths'] );
 					$mtime = max( array_map( 'filemtime', $paths ) );
-					$path_str = implode( ',', $js_array['paths'] ) . "?m=${mtime}j";
+					$path_str = implode( ',', $js_array['paths'] ) . "?m=${mtime}";
 
 					if ( $this->allow_gzip_compression ) {
 						$path_64 = base64_encode( gzcompress( $path_str ) );

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -4,7 +4,7 @@ Plugin Name: Page Optimize
 Plugin URI: https://wordpress.org/plugins/page-optimize/
 Description: Optimizes JS and CSS for faster page load and render in the browser.
 Author: Automattic
-Version: 0.1.2
+Version: 0.1.3
 Author URI: http://automattic.com/
 */
 
@@ -132,9 +132,18 @@ function page_optimize_sanitize_exclude_field( $value ) {
 	return implode( ',', $sanitized_values );
 }
 
-require_once __DIR__ . '/settings.php';
-require_once __DIR__ . '/concat-css.php';
-require_once __DIR__ . '/concat-js.php';
+function page_optimize_init() {
+	// Bail if we're in customizer
+	global $wp_customize;
+	if ( isset( $wp_customize ) ) {
+		return;
+	}
 
-// Disable Jetpack photon-cdn for static JS/CSS
-add_filter( 'jetpack_force_disable_site_accelerator', '__return_true' );
+	require_once __DIR__ . '/settings.php';
+	require_once __DIR__ . '/concat-css.php';
+	require_once __DIR__ . '/concat-js.php';
+
+	// Disable Jetpack photon-cdn for static JS/CSS
+	add_filter( 'jetpack_force_disable_site_accelerator', '__return_true' );
+}
+add_action( 'plugins_loaded', 'page_optimize_init' );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: performance
 Requires at least: 5.3
 Tested up to: 5.3
 Requires PHP: 7.2
-Stable tag: 0.1.2
+Stable tag: 0.1.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
Users were seeing errors when in Customizer. Just skip
all concat/minify stuff when in there.