### PR TITLE
Fix Customizer conflict in a simpler way

### DIFF
--- a/concat-css.php
+++ b/concat-css.php
@@ -246,6 +246,6 @@ function css_concat_init() {
 	$wp_styles->allow_gzip_compression = ALLOW_GZIP_COMPRESSION;
 }
 
-if ( page_optimize_should_concat_css() ) {
+if ( ! is_admin() && page_optimize_should_concat_css() ) {
 	add_action( 'init', 'css_concat_init' );
 }

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -132,18 +132,9 @@ function page_optimize_sanitize_exclude_field( $value ) {
 	return implode( ',', $sanitized_values );
 }
 
-function page_optimize_init() {
-	// Bail if we're in customizer
-	global $wp_customize;
-	if ( isset( $wp_customize ) ) {
-		return;
-	}
+require_once __DIR__ . '/settings.php';
+require_once __DIR__ . '/concat-css.php';
+require_once __DIR__ . '/concat-js.php';
 
-	require_once __DIR__ . '/settings.php';
-	require_once __DIR__ . '/concat-css.php';
-	require_once __DIR__ . '/concat-js.php';
-
-	// Disable Jetpack photon-cdn for static JS/CSS
-	add_filter( 'jetpack_force_disable_site_accelerator', '__return_true' );
-}
-add_action( 'plugins_loaded', 'page_optimize_init' );
+// Disable Jetpack photon-cdn for static JS/CSS
+add_filter( 'jetpack_force_disable_site_accelerator', '__return_true' );


### PR DESCRIPTION
Currently, we are looking at the $wp_customizer global to determine
whether we are in a Customizer context. But we don't really want to
concat styles in the admin anyway, so we can guard CSS concat with
`! is_admin()` to avoid this and similar issues entirely

This has been tested successfully with the Colinear and Canard themes. I tried to reproduce the issue with the Fortune theme but was not able.