### PR TITLE
Address plugin directory feedback

### DIFF
--- a/concat-css.php
+++ b/concat-css.php
@@ -8,9 +8,10 @@ if ( ! defined( 'ALLOW_GZIP_COMPRESSION' ) ) {
 }
 
 class Page_Optimize_CSS_Concat extends WP_Styles {
-	private $old_styles;
-	public $allow_gzip_compression;
 	private $dependency_path_mapping;
+	private $old_styles;
+
+	public $allow_gzip_compression;
 
 	function __construct( $styles ) {
 		if ( empty( $styles ) || ! ( $styles instanceof WP_Styles ) ) {

--- a/concat-css.php
+++ b/concat-css.php
@@ -101,7 +101,7 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 
 			if ( $do_concat ) {
 				// Resolve paths and concat styles that exist in the filesystem
-				$css_realpath = $this->dependency_path_mapping->dependency_src_to_local_fs_path( $css_url );
+				$css_realpath = $this->dependency_path_mapping->dependency_src_to_fs_path( $css_url );
 				if ( false === $css_realpath ) {
 					if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 						echo sprintf( "\n<!-- No Concat CSS %s => Invalid Path %s -->\n", esc_html( $handle ), esc_html( $css_realpath ) );
@@ -156,8 +156,8 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 					continue;
 				} elseif ( count( $css ) > 1 ) {
 					$paths = array();
-					foreach ( $css as $css_url ) {
-						$paths[] = $this->dependency_path_mapping->dependency_src_to_local_fs_path( $css_url );
+					foreach ( $css as $css_uri_path ) {
+						$paths[] = $this->dependency_path_mapping->uri_path_to_fs_path( $css_uri_path );
 					}
 
 					$mtime = max( array_map( 'filemtime', $paths ) );
@@ -199,7 +199,7 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 			return $url;
 		}
 
-		$file = $this->dependency_path_mapping->dependency_src_to_local_fs_path( $url );
+		$file = $this->dependency_path_mapping->uri_path_to_fs_path( $url );
 
 		$mtime = false;
 		if ( file_exists( $file ) ) {

--- a/concat-css.php
+++ b/concat-css.php
@@ -1,5 +1,7 @@
 <?php
-require_once( __DIR__ . '/utils.php' );
+
+require_once __DIR__ . '/dependency-path-mapping.php';
+require_once __DIR__ . '/utils.php';
 
 if ( ! defined( 'ALLOW_GZIP_COMPRESSION' ) ) {
 	define( 'ALLOW_GZIP_COMPRESSION', true );
@@ -8,6 +10,7 @@ if ( ! defined( 'ALLOW_GZIP_COMPRESSION' ) ) {
 class Page_Optimize_CSS_Concat extends WP_Styles {
 	private $old_styles;
 	public $allow_gzip_compression;
+	private $dependency_path_mapping;
 
 	function __construct( $styles ) {
 		if ( empty( $styles ) || ! ( $styles instanceof WP_Styles ) ) {
@@ -25,6 +28,10 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 			}
 			unset( $this->$key );
 		}
+
+		$this->dependency_path_mapping = new Page_Optimize_Dependency_Path_Mapping(
+			apply_filters( 'page_optimize_site_url', $this->base_url )
+		);
 	}
 
 	function do_items( $handles = false, $group = false ) {
@@ -84,18 +91,18 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 			}
 
 			// Don't try to concat externally hosted scripts
-			$is_internal_url = Page_Optimize_Utils::is_internal_url( $css_url, $siteurl );
-			if ( $do_concat && ! $is_internal_url ) {
+			$is_internal_uri = $this->dependency_path_mapping->is_internal_uri( $css_url );
+			if ( $do_concat && ! $is_internal_uri ) {
 				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 					echo sprintf( "\n<!-- No Concat CSS %s => External URL: %s -->\n", esc_html( $handle ), esc_url( $css_url ) );
 				}
 				$do_concat = false;
 			}
 
-			// Concat scripts that aren't outside ABSPATH
 			if ( $do_concat ) {
-				$css_realpath = Page_Optimize_Utils::realpath( $css_url, $siteurl );
-				if ( ! $css_realpath || ! file_exists( $css_realpath ) ) {
+				// Resolve paths and concat styles that exist in the filesystem
+				$css_realpath = $this->dependency_path_mapping->dependency_src_to_local_fs_path( $css_url );
+				if ( false === $css_realpath ) {
 					if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 						echo sprintf( "\n<!-- No Concat CSS %s => Invalid Path %s -->\n", esc_html( $handle ), esc_html( $css_realpath ) );
 					}
@@ -148,18 +155,11 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 					}
 					continue;
 				} elseif ( count( $css ) > 1 ) {
-					$paths = array_map( function ( $url ) {
-						$path = ABSPATH . $url;
+					$paths = array();
+					foreach ( $css as $css_url ) {
+						$paths[] = $this->dependency_path_mapping->dependency_src_to_local_fs_path( $css_url );
+					}
 
-						if ( ! file_exists( $path )
-							&& false !== strpos( $url, '/wp-content/' )
-							&& defined( 'WP_CONTENT_DIR' )
-						) {
-							$path = str_replace( '/wp-content', WP_CONTENT_DIR, $url );
-						}
-
-						return $path;
-					}, $css );
 					$mtime = max( array_map( 'filemtime', $paths ) );
 					$path_str = implode( ',', $css ) . "?m={$mtime}";
 
@@ -199,7 +199,7 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 			return $url;
 		}
 
-		$file = Page_Optimize_Utils::realpath( $url, $siteurl );
+		$file = $this->dependency_path_mapping->dependency_src_to_local_fs_path( $url );
 
 		$mtime = false;
 		if ( file_exists( $file ) ) {

--- a/concat-js.php
+++ b/concat-js.php
@@ -8,9 +8,10 @@ if ( ! defined( 'ALLOW_GZIP_COMPRESSION' ) ) {
 }
 
 class Page_Optimize_JS_Concat extends WP_Scripts {
-	private $old_scripts;
-	public $allow_gzip_compression;
 	private $dependency_path_mapping;
+	private $old_scripts;
+
+	public $allow_gzip_compression;
 
 	function __construct( $scripts ) {
 		if ( empty( $scripts ) || ! ( $scripts instanceof WP_Scripts ) ) {

--- a/concat-js.php
+++ b/concat-js.php
@@ -112,7 +112,7 @@ class Page_Optimize_JS_Concat extends WP_Scripts {
 
 			if ( $do_concat ) {
 				// Resolve paths and concat scripts that exist in the filesystem
-				$js_realpath = $this->dependency_path_mapping->dependency_src_to_local_fs_path( $js_url );
+				$js_realpath = $this->dependency_path_mapping->dependency_src_to_fs_path( $js_url );
 				if ( false === $js_realpath ) {
 					if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 						echo sprintf( "\n<!-- No Concat JS %s => Invalid Path %s -->\n", esc_html( $handle ), esc_html( $js_realpath ) );
@@ -210,7 +210,7 @@ class Page_Optimize_JS_Concat extends WP_Scripts {
 				if ( isset( $js_array['paths'] ) && count( $js_array['paths'] ) > 1 ) {
 					$paths = array();
 					foreach ( $js_array['paths'] as $js_url ) {
-						$paths[] = $this->dependency_path_mapping->dependency_src_to_local_fs_path( $js_url );
+						$paths[] = $this->dependency_path_mapping->uri_path_to_fs_path( $js_url );
 					}
 
 					$mtime = max( array_map( 'filemtime', $paths ) );
@@ -272,7 +272,7 @@ class Page_Optimize_JS_Concat extends WP_Scripts {
 			return $url;
 		}
 
-		$file = $this->dependency_path_mapping->dependency_src_to_local_fs_path( $url );
+		$file = $this->dependency_path_mapping->uri_path_to_fs_path( $url );
 
 		$mtime = false;
 		if ( file_exists( $file ) ) {

--- a/dependency-path-mapping.php
+++ b/dependency-path-mapping.php
@@ -47,12 +47,9 @@ class Page_Optimize_Dependency_Path_Mapping {
 	}
 
 	/**
-	 * Given the URL of a script/style dependency, return its local filesystem path.
-	 *
-	 * This function is useful when determining which script and style dependencies
-	 * can be concatenated.
+	 * Given the full URL of a script/style dependency, return its local filesystem path.
 	 */
-	function dependency_src_to_local_fs_path( $src ) {
+	function dependency_src_to_fs_path( $src ) {
 		if ( ! $this->is_internal_uri( $src ) ) {
 			// If a URI is not internal, we can have no confidence
 			// we are resolving to the correct file.
@@ -80,10 +77,6 @@ class Page_Optimize_Dependency_Path_Mapping {
 
 	/**
 	 * Given a URI path of a script/style resource, return its local filesystem path.
-	 *
-	 * This function is useful when building the concatenated content.
-	 * We have a list of resource paths that need to be located on the filesystem
-	 * before they can be concatenated.
 	 */
 	function uri_path_to_fs_path( $uri_path ) {
 		if ( 1 === preg_match( '#(?:^|/)\.\.?(?:/|$)#', $uri_path ) ) {

--- a/dependency-path-mapping.php
+++ b/dependency-path-mapping.php
@@ -128,6 +128,7 @@ class Page_Optimize_Dependency_Path_Mapping {
 		// Ensure a trailing slash to avoid false matches like
 		// "/wp-content/resource" being judged a descendant of "/wp".
 		$dir_path = trailingslashit( $dir_path );
+
 		return static::starts_with( $dir_path, $candidate );
 	}
 
@@ -139,6 +140,7 @@ class Page_Optimize_Dependency_Path_Mapping {
 		if ( strlen( $str ) < $prefix_length ) {
 			return false;
 		}
+
 		return substr( $str, 0, $prefix_length ) === $prefix;
 	}
 
@@ -154,6 +156,7 @@ class Page_Optimize_Dependency_Path_Mapping {
 		// Create a mask so we can focus on just the keys we care about.
 		// That way, results from this function can be simply compared for equality with `==`.
 		$key_mask = array( 'scheme' => 0, 'host' => 0, 'port' => 0 );
+
 		return array_intersect_key( $url_parts, $key_mask );
 	}
 }

--- a/dependency-path-mapping.php
+++ b/dependency-path-mapping.php
@@ -1,0 +1,166 @@
+<?php
+
+/**
+ * This is a class to map script and style URLs to local filesystem paths.
+ * This is necessary when we are deciding what we can concatenate and when
+ * actually building the concatenation.
+ */
+class Page_Optimize_Dependency_Path_Mapping {
+	// Save entire site URL so we can check whether other URLs are based on it (internal URLs)
+	public $site_url;
+
+	// Save URI path and dir for mapping URIs to filesystem paths
+	public $site_uri_path = null;
+	public $site_dir = null;
+	public $content_uri_path = null;
+	public $content_dir = null;
+	public $plugin_uri_path = null;
+	public $plugin_dir = null;
+
+	function __construct(
+		// Expose URLs and DIRs for unit test
+		$site_url = null, // default site URL is determined dynamically
+		$site_dir = ABSPATH,
+		$content_url = WP_CONTENT_URL,
+		$content_dir = WP_CONTENT_DIR,
+		$plugin_url = WP_PLUGIN_URL,
+		$plugin_dir = WP_PLUGIN_DIR
+	) {
+		if ( null === $site_url ) {
+			$site_url = is_multisite() ? get_site_url( get_current_blog_id() ) : get_site_url();
+		}
+		$this->site_url = trailingslashit( $site_url );
+		$this->site_uri_path = parse_url( $site_url, PHP_URL_PATH );
+		$this->site_dir = trailingslashit( $site_dir );
+
+		// Only resolve content URLs if they are under the site URL
+		if ( $this->is_internal_uri( $content_url ) ) {
+			$this->content_uri_path = parse_url( trailingslashit( $content_url ), PHP_URL_PATH );
+			$this->content_dir = trailingslashit( $content_dir );
+		}
+
+		// Only resolve plugin URLs if they are under the site URL
+		if ( $this->is_internal_uri( $plugin_url ) ) {
+			$this->plugin_uri_path = parse_url( trailingslashit( $plugin_url ), PHP_URL_PATH );
+			$this->plugin_dir = trailingslashit( $plugin_dir );
+		}
+	}
+
+	/**
+	 * Given the URL of a script/style dependency, return its local filesystem path.
+	 *
+	 * This function is useful when determining which script and style dependencies
+	 * can be concatenated.
+	 */
+	function dependency_src_to_local_fs_path( $src ) {
+		if ( ! $this->is_internal_uri( $src ) ) {
+			// If a URI is not internal, we can have no confidence
+			// we are resolving to the correct file.
+			return false;
+		}
+
+		$src_parts = parse_url( $src );
+		if ( false === $src_parts ) {
+			return false;
+		}
+
+		if ( empty( $src_parts['path'] ) ) {
+			// We can't find anything to resolve
+			return false;
+		}
+		$path = $src_parts['path'];
+
+		if ( empty( $src_parts['host'] ) ) {
+			// With no host, this is a path relative to the WordPress root
+			return realpath( "{$this->site_dir}{$path}" );
+		}
+
+		return $this->uri_path_to_fs_path( $path );
+	}
+
+	/**
+	 * Given a URI path of a script/style resource, return its local filesystem path.
+	 *
+	 * This function is useful when building the concatenated content.
+	 * We have a list of resource paths that need to be located on the filesystem
+	 * before they can be concatenated.
+	 */
+	function uri_path_to_fs_path( $uri_path ) {
+		if ( 1 === preg_match( '#(?:^|/)\.\.?(?:/|$)#', $uri_path ) ) {
+			// Reject relative paths
+			return false;
+		}
+
+		// The plugin URI path may be contained within the content URI path, so we check it before the content URI.
+		// And both the plugin and content URI paths must be contained within the site URI path,
+		// so we check them before checking the site URI.
+		if ( isset( $this->plugin_uri_path ) && static::is_descendant_uri( $this->plugin_uri_path, $uri_path ) ) {
+			$file_path = $this->plugin_dir . substr( $uri_path, strlen( $this->plugin_uri_path ) );
+		} else if ( isset( $this->content_uri_path ) && static::is_descendant_uri( $this->content_uri_path, $uri_path ) ) {
+			$file_path = $this->content_dir . substr( $uri_path, strlen( $this->content_uri_path ) );
+		} else if ( static::is_descendant_uri( $this->site_uri_path, $uri_path ) ) {
+			$file_path = $this->site_dir . substr( $uri_path, strlen( $this->site_uri_path ) );
+		}
+
+		if ( isset( $file_path ) ) {
+			return realpath( $file_path );
+		} else {
+			return false;
+		}
+	}
+
+	/**
+	 * Determine whether a URI is internal, contained by this site.
+	 *
+	 * This method helps ensure we only resolve to local FS paths.
+	 */
+	function is_internal_uri( $uri ) {
+		if ( static::starts_with( '/', $uri ) && ! static::starts_with( '//', $uri ) ) {
+			// Absolute paths are internal because they are based on the site dir (ABSPATH),
+			// and this looks like an absolute path.
+			return true;
+		}
+
+		// To be internal, a URL must have the same scheme, host, and port as the site URL
+		// and start with the same path as the site URL.
+		return static::is_descendant_uri( $this->site_url, $uri );
+	}
+
+	/**
+	 * Check whether a path is descended from the given directory path.
+	 *
+	 * Does not handle relative paths.
+	 */
+	static function is_descendant_uri( $dir_path, $candidate ) {
+		// Ensure a trailing slash to avoid false matches like
+		// "/wp-content/resource" being judged a descendant of "/wp".
+		$dir_path = trailingslashit( $dir_path );
+		return static::starts_with( $dir_path, $candidate );
+	}
+
+	/**
+	 * Determines whether a string starts with another string.
+	 */
+	static function starts_with( $prefix, $str ) {
+		$prefix_length = strlen( $prefix );
+		if ( strlen( $str ) < $prefix_length ) {
+			return false;
+		}
+		return substr( $str, 0, $prefix_length ) === $prefix;
+	}
+
+	/**
+	 * Get a URL's scheme, host, and port for later comparison.
+	 */
+	static function get_url_scheme_and_host( $url ) {
+		$url_parts = parse_url( $url );
+		if ( false === $url_parts ) {
+			return array();
+		}
+
+		// Create a mask so we can focus on just the keys we care about.
+		// That way, results from this function can be simply compared for equality with `==`.
+		$key_mask = array( 'scheme' => 0, 'host' => 0, 'port' => 0 );
+		return array_intersect_key( $url_parts, $key_mask );
+	}
+}

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -4,7 +4,7 @@ Plugin Name: Page Optimize
 Plugin URI: https://wordpress.org/plugins/page-optimize/
 Description: Optimizes JS and CSS for faster page load and render in the browser.
 Author: Automattic
-Version: 0.2.1
+Version: 0.3.0
 Author URI: http://automattic.com/
 */
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: performance
 Requires at least: 5.3
 Tested up to: 5.3
 Requires PHP: 7.2
-Stable tag: 0.2.1
+Stable tag: 0.3.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/service.php
+++ b/service.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once __DIR__ . '/dependency-path-mapping.php';
+
 $page_optimize_types = array(
 	'css' => 'text/css',
 	'js' => 'application/javascript'
@@ -279,6 +281,11 @@ function page_optimize_get_mime_type( $file ) {
 }
 
 function page_optimize_get_path( $uri ) {
+	static $dependency_path_mapping;
+	if ( empty( $dependency_path_mapping ) ) {
+		$dependency_path_mapping = new Page_Optimize_Dependency_Path_Mapping();
+	}
+
 	if ( ! strlen( $uri ) ) {
 		page_optimize_status_exit( 400 );
 	}
@@ -287,13 +294,9 @@ function page_optimize_get_path( $uri ) {
 		page_optimize_status_exit( 400 );
 	}
 
-	if ( false !== strpos( $uri, '/wp-content/' ) && defined( 'WP_CONTENT_DIR' ) ) {
-		$files_root = WP_CONTENT_DIR;
-		$replace_count = 1;
-		$uri = str_replace( '/wp-content/', '', $uri, $replace_count ); // Remove duplicate /wp-content/
-	} else {
-		$files_root = ABSPATH;
+	$path = $dependency_path_mapping->uri_path_to_fs_path( $uri );
+	if ( false === $path ) {
+		page_optimize_status_exit( 404 );
 	}
-
-	return $files_root . ( '/' != $uri[0] ? '/' : '' ) . $uri;
+	return $path;
 }

--- a/service.php
+++ b/service.php
@@ -87,8 +87,8 @@ function page_optimize_build_output() {
 	global $page_optimize_types;
 	ob_start( 'ob_gzhandler' );
 
-	require_once( __DIR__ . '/cssmin/cssmin.php' );
-	require_once( __DIR__ . '/utils.php' );
+	require_once __DIR__ . '/cssmin/cssmin.php';
+	require_once __DIR__ . '/utils.php';
 
 	/* Config */
 	$concat_max_files = 150;
@@ -298,5 +298,6 @@ function page_optimize_get_path( $uri ) {
 	if ( false === $path ) {
 		page_optimize_status_exit( 404 );
 	}
+
 	return $path;
 }

--- a/utils.php
+++ b/utils.php
@@ -1,53 +1,6 @@
 <?php
-// TODO: Rename file according to traditional class file naming
 
 class Page_Optimize_Utils {
-	public static function is_internal_url( $test_url, $site_url ) {
-		$test_url_parsed = parse_url( $test_url );
-		$site_url_parsed = parse_url( $site_url );
-
-		if ( isset( $test_url_parsed['host'] ) && $test_url_parsed['host'] !== $site_url_parsed['host'] ) {
-			return false;
-		}
-
-		if ( isset( $site_url_parsed['path'] )
-			&& 0 !== strpos( $test_url_parsed['path'], $site_url_parsed['path'] )
-			&& isset( $test_url_parsed['host'] ) //and if the URL of enqueued style is not relative
-		) {
-			return false;
-		}	
-
-		return true;
-	}
-
-	public static function realpath( $url, $site_url ) {
-		$url_path = parse_url( $url, PHP_URL_PATH );
-		$site_url_path = parse_url( $site_url, PHP_URL_PATH );
-		// To avoid partial matches; subdir install at `/wp` would match `/wp-includes`
-		$site_url_path = trailingslashit( $site_url_path );
-
-		// If this is a subdirectory site, we need to strip off the subdir from the URL.
-		// In a multisite install, the subdir is virtual and therefore not needed in the path.
-		// In a single-site subdir install, the subdir is included in the ABSPATH and therefore ends up duplicated.
-		if ( $site_url_path && '/' !== $site_url_path
-			&& 0 === strpos( $url_path, $site_url_path ) ) {
-			$url_path = preg_replace( '#^' . $site_url_path . '#', '', $url_path, 1 );
-		}
-
-		$realpath = realpath( ABSPATH . $url_path );
-
-		// If `/wp-content/` is in a non-traditional directory, we may need to adjust.
-		if ( ! file_exists( $realpath )
-			&& false !== strpos( $url_path, '/wp-content/' )
-			&& defined( 'WP_CONTENT_DIR' )
-		) {
-			$url_path = str_replace( '/wp-content', WP_CONTENT_DIR, $url_path );
-			$realpath = realpath( $url_path );
-		}
-
-		return $realpath;
-	}
-
 	public static function relative_path_replace( $buf, $dirpath ) {
 		// url(relative/path/to/file) -> url(/absolute/and/not/relative/path/to/file)
 		$buf = preg_replace(


### PR DESCRIPTION
We submitted this to the plugin directory and received helpful critical feedback.

The plugin doesn't resolve the locations of JS and CSS files in a way that will work with all WordPress installations. The purpose of this PR is to resolve that issue.

The actual feedback:

> ## Calling file locations poorly
> 
> The way your plugin is referencing other files is not going to work with all setups of WordPress.
> 
> When you hardcode in paths like wp-content or your plugin folder name, or assume that everyone has WordPress in the root of their domain, you cause anyone using 'Giving WordPress it's own directory' (a VERY common setup) to break. In addition, WordPress allows users to change the name of wp-content, so you would break anyone who chooses to do so.
> 
> Please review the following link and update your plugin accordingly. And don't worry about supporting WordPress 2.x or lower. We don't encourage it nor expect you to do so, so save yourself some time and energy.
> 
> * https://developer.wordpress.org/plugins/plugin-basics/determining-plugin-and-content-directories/
> 
> Remember to make use of the __FILE__ variable, in order than your plugin function properly in the real world.
> 
> Example(s) from your plugin:
> 
> page-optimize/utils.php:44: $url_path = str_replace( '/wp-content', WP_CONTENT_DIR, $url_path );
> 
> That's not going to work in all cases.
