### PR TITLE
Update concat service to run without loading WordPress

### DIFF
--- a/concat-css.php
+++ b/concat-css.php
@@ -162,7 +162,7 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 					}
 
 					$mtime = max( array_map( 'filemtime', $fs_paths ) );
-					if ( page_optimize_has_concat_base_dir() ) {
+					if ( page_optimize_use_concat_base_dir() ) {
 						$path_str = implode( ',', array_map( 'page_optimize_remove_concat_base_prefix', $fs_paths ) );
 					} else {
 						$path_str = implode( ',', $css );

--- a/concat-css.php
+++ b/concat-css.php
@@ -162,8 +162,8 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 					}
 
 					$mtime = max( array_map( 'filemtime', $fs_paths ) );
-					if ( page_optimize_has_resource_base_path() ) {
-						$path_str = implode( ',', array_map( 'page_optimize_remove_resource_base_path', $fs_paths ) );
+					if ( page_optimize_has_resource_base_dir() ) {
+						$path_str = implode( ',', array_map( 'page_optimize_remove_resource_base_prefix', $fs_paths ) );
 					} else {
 						$path_str = implode( ',', $css );
 					}

--- a/concat-css.php
+++ b/concat-css.php
@@ -156,13 +156,18 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 					}
 					continue;
 				} elseif ( count( $css ) > 1 ) {
-					$paths = array();
+					$fs_paths = array();
 					foreach ( $css as $css_uri_path ) {
-						$paths[] = $this->dependency_path_mapping->uri_path_to_fs_path( $css_uri_path );
+						$fs_paths[] = $this->dependency_path_mapping->uri_path_to_fs_path( $css_uri_path );
 					}
 
-					$mtime = max( array_map( 'filemtime', $paths ) );
-					$path_str = implode( ',', $css ) . "?m={$mtime}";
+					$mtime = max( array_map( 'filemtime', $fs_paths ) );
+					if ( page_optimize_has_resource_base_path() ) {
+						$path_str = implode( ',', array_map( 'page_optimize_remove_resource_base_path', $fs_paths ) );
+					} else {
+						$path_str = implode( ',', $css );
+					}
+					$path_str = "$path_str?m=$mtime";
 
 					if ( $this->allow_gzip_compression ) {
 						$path_64 = base64_encode( gzcompress( $path_str ) );

--- a/concat-css.php
+++ b/concat-css.php
@@ -162,8 +162,8 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 					}
 
 					$mtime = max( array_map( 'filemtime', $fs_paths ) );
-					if ( page_optimize_has_resource_base_dir() ) {
-						$path_str = implode( ',', array_map( 'page_optimize_remove_resource_base_prefix', $fs_paths ) );
+					if ( page_optimize_has_concat_base_dir() ) {
+						$path_str = implode( ',', array_map( 'page_optimize_remove_concat_base_prefix', $fs_paths ) );
 					} else {
 						$path_str = implode( ',', $css );
 					}

--- a/concat-js.php
+++ b/concat-js.php
@@ -215,8 +215,8 @@ class Page_Optimize_JS_Concat extends WP_Scripts {
 					}
 
 					$mtime = max( array_map( 'filemtime', $fs_paths ) );
-					if ( page_optimize_has_resource_base_dir() ) {
-						$path_str = implode( ',', array_map( 'page_optimize_remove_resource_base_prefix', $fs_paths ) );
+					if ( page_optimize_has_concat_base_dir() ) {
+						$path_str = implode( ',', array_map( 'page_optimize_remove_concat_base_prefix', $fs_paths ) );
 					} else {
 						$path_str = implode( ',', $js_array['paths'] );
 					}

--- a/concat-js.php
+++ b/concat-js.php
@@ -215,7 +215,7 @@ class Page_Optimize_JS_Concat extends WP_Scripts {
 					}
 
 					$mtime = max( array_map( 'filemtime', $fs_paths ) );
-					if ( page_optimize_has_concat_base_dir() ) {
+					if ( page_optimize_use_concat_base_dir() ) {
 						$path_str = implode( ',', array_map( 'page_optimize_remove_concat_base_prefix', $fs_paths ) );
 					} else {
 						$path_str = implode( ',', $js_array['paths'] );

--- a/concat-js.php
+++ b/concat-js.php
@@ -292,6 +292,6 @@ function js_concat_init() {
 	$wp_scripts->allow_gzip_compression = ALLOW_GZIP_COMPRESSION;
 }
 
-if ( page_optimize_should_concat_js() || page_optimize_load_mode_js() ) {
+if ( ! is_admin() && ( page_optimize_should_concat_js() || page_optimize_load_mode_js() ) ) {
 	add_action( 'init', 'js_concat_init' );
 }

--- a/concat-js.php
+++ b/concat-js.php
@@ -292,6 +292,6 @@ function js_concat_init() {
 	$wp_scripts->allow_gzip_compression = ALLOW_GZIP_COMPRESSION;
 }
 
-if ( ! is_admin() && ( page_optimize_should_concat_js() || page_optimize_load_mode_js() ) ) {
+if ( page_optimize_should_concat_js() || page_optimize_load_mode_js() ) {
 	add_action( 'init', 'js_concat_init' );
 }

--- a/concat-js.php
+++ b/concat-js.php
@@ -215,8 +215,8 @@ class Page_Optimize_JS_Concat extends WP_Scripts {
 					}
 
 					$mtime = max( array_map( 'filemtime', $fs_paths ) );
-					if ( page_optimize_has_resource_base_path() ) {
-						$path_str = implode( ',', array_map( 'page_optimize_remove_resource_base_path', $fs_paths ) );
+					if ( page_optimize_has_resource_base_dir() ) {
+						$path_str = implode( ',', array_map( 'page_optimize_remove_resource_base_prefix', $fs_paths ) );
 					} else {
 						$path_str = implode( ',', $js_array['paths'] );
 					}

--- a/concat-js.php
+++ b/concat-js.php
@@ -209,13 +209,18 @@ class Page_Optimize_JS_Concat extends WP_Scripts {
 				array_map( array( $this, 'print_extra_script' ), $js_array['handles'] );
 
 				if ( isset( $js_array['paths'] ) && count( $js_array['paths'] ) > 1 ) {
-					$paths = array();
+					$fs_paths = array();
 					foreach ( $js_array['paths'] as $js_url ) {
-						$paths[] = $this->dependency_path_mapping->uri_path_to_fs_path( $js_url );
+						$fs_paths[] = $this->dependency_path_mapping->uri_path_to_fs_path( $js_url );
 					}
 
-					$mtime = max( array_map( 'filemtime', $paths ) );
-					$path_str = implode( ',', $js_array['paths'] ) . "?m=${mtime}";
+					$mtime = max( array_map( 'filemtime', $fs_paths ) );
+					if ( page_optimize_has_resource_base_path() ) {
+						$path_str = implode( ',', array_map( 'page_optimize_remove_resource_base_path', $fs_paths ) );
+					} else {
+						$path_str = implode( ',', $js_array['paths'] );
+					}
+					$path_str = "$path_str?m=$mtime";
 
 					if ( $this->allow_gzip_compression ) {
 						$path_64 = base64_encode( gzcompress( $path_str ) );

--- a/dependency-path-mapping.php
+++ b/dependency-path-mapping.php
@@ -20,7 +20,7 @@ class Page_Optimize_Dependency_Path_Mapping {
 	function __construct(
 		// Expose URLs and DIRs for unit test
 		$site_url = null, // default site URL is determined dynamically
-		$site_dir = PAGE_OPTIMIZE_SITE_ROOT_DIR,
+		$site_dir = PAGE_OPTIMIZE_DEFAULT_RESOURCE_ROOT_DIR,
 		$content_url = WP_CONTENT_URL,
 		$content_dir = WP_CONTENT_DIR,
 		$plugin_url = WP_PLUGIN_URL,
@@ -69,7 +69,8 @@ class Page_Optimize_Dependency_Path_Mapping {
 
 		if ( empty( $src_parts['host'] ) ) {
 			// With no host, this is a path relative to the WordPress root
-			return realpath( "{$this->site_dir}{$path}" );
+			$fs_path = "{$this->site_dir}{$path}";
+			return file_exists( $fs_path ) ? $fs_path : false;
 		}
 
 		return $this->uri_path_to_fs_path( $path );
@@ -95,8 +96,8 @@ class Page_Optimize_Dependency_Path_Mapping {
 			$file_path = $this->site_dir . substr( $uri_path, strlen( $this->site_uri_path ) );
 		}
 
-		if ( isset( $file_path ) ) {
-			return realpath( $file_path );
+		if ( isset( $file_path ) && file_exists( $file_path ) ) {
+			return $file_path;
 		} else {
 			return false;
 		}

--- a/dependency-path-mapping.php
+++ b/dependency-path-mapping.php
@@ -108,7 +108,7 @@ class Page_Optimize_Dependency_Path_Mapping {
 	 * This method helps ensure we only resolve to local FS paths.
 	 */
 	function is_internal_uri( $uri ) {
-		if ( static::starts_with( '/', $uri ) && ! static::starts_with( '//', $uri ) ) {
+		if ( page_optimize_starts_with( '/', $uri ) && ! page_optimize_starts_with( '//', $uri ) ) {
 			// Absolute paths are internal because they are based on the site dir (ABSPATH),
 			// and this looks like an absolute path.
 			return true;
@@ -129,18 +129,6 @@ class Page_Optimize_Dependency_Path_Mapping {
 		// "/wp-content/resource" being judged a descendant of "/wp".
 		$dir_path = trailingslashit( $dir_path );
 
-		return static::starts_with( $dir_path, $candidate );
-	}
-
-	/**
-	 * Determines whether a string starts with another string.
-	 */
-	static function starts_with( $prefix, $str ) {
-		$prefix_length = strlen( $prefix );
-		if ( strlen( $str ) < $prefix_length ) {
-			return false;
-		}
-
-		return substr( $str, 0, $prefix_length ) === $prefix;
+		return page_optimize_starts_with( $dir_path, $candidate );
 	}
 }

--- a/dependency-path-mapping.php
+++ b/dependency-path-mapping.php
@@ -20,7 +20,7 @@ class Page_Optimize_Dependency_Path_Mapping {
 	function __construct(
 		// Expose URLs and DIRs for unit test
 		$site_url = null, // default site URL is determined dynamically
-		$site_dir = PAGE_OPTIMIZE_DEFAULT_RESOURCE_ROOT_DIR,
+		$site_dir = PAGE_OPTIMIZE_ABSPATH,
 		$content_url = WP_CONTENT_URL,
 		$content_dir = WP_CONTENT_DIR,
 		$plugin_url = WP_PLUGIN_URL,

--- a/dependency-path-mapping.php
+++ b/dependency-path-mapping.php
@@ -20,7 +20,7 @@ class Page_Optimize_Dependency_Path_Mapping {
 	function __construct(
 		// Expose URLs and DIRs for unit test
 		$site_url = null, // default site URL is determined dynamically
-		$site_dir = ABSPATH,
+		$site_dir = PAGE_OPTIMIZE_SITE_ROOT_DIR,
 		$content_url = WP_CONTENT_URL,
 		$content_dir = WP_CONTENT_DIR,
 		$plugin_url = WP_PLUGIN_URL,
@@ -109,7 +109,7 @@ class Page_Optimize_Dependency_Path_Mapping {
 	 */
 	function is_internal_uri( $uri ) {
 		if ( page_optimize_starts_with( '/', $uri ) && ! page_optimize_starts_with( '//', $uri ) ) {
-			// Absolute paths are internal because they are based on the site dir (ABSPATH),
+			// Absolute paths are internal because they are based on the site dir (typically ABSPATH),
 			// and this looks like an absolute path.
 			return true;
 		}

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -13,6 +13,10 @@ if ( ! defined( 'PAGE_OPTIMIZE_CACHE_DIR' ) ) {
 	define( 'PAGE_OPTIMIZE_CACHE_DIR', WP_CONTENT_DIR . '/cache/page_optimize' );
 }
 
+if ( ! defined( 'PAGE_OPTIMIZE_SITE_ROOT_DIR' ) ) {
+	define( 'PAGE_OPTIMIZE_SITE_ROOT_DIR', ABSPATH );
+}
+
 define( 'PAGE_OPTIMIZE_CRON_CACHE_CLEANUP_JOB', 'page_optimize_cron_cache_cleanup' );
 
 // TODO: Copy tests from nginx-http-concat and/or write them

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -13,8 +13,8 @@ if ( ! defined( 'PAGE_OPTIMIZE_CACHE_DIR' ) ) {
 	define( 'PAGE_OPTIMIZE_CACHE_DIR', WP_CONTENT_DIR . '/cache/page_optimize' );
 }
 
-if ( ! defined( 'PAGE_OPTIMIZE_DEFAULT_RESOURCE_ROOT_DIR' ) ) {
-	define( 'PAGE_OPTIMIZE_DEFAULT_RESOURCE_ROOT_DIR', ABSPATH );
+if ( ! defined( 'PAGE_OPTIMIZE_ABSPATH' ) ) {
+	define( 'PAGE_OPTIMIZE_ABSPATH', ABSPATH );
 }
 
 define( 'PAGE_OPTIMIZE_CRON_CACHE_CLEANUP_JOB', 'page_optimize_cron_cache_cleanup' );

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -179,6 +179,46 @@ function page_optimize_sanitize_exclude_field( $value ) {
 	return implode( ',', $sanitized_values );
 }
 
+/**
+ * Determines whether a string starts with another string.
+ */
+function page_optimize_starts_with( $prefix, $str ) {
+	$prefix_length = strlen( $prefix );
+	if ( strlen( $str ) < $prefix_length ) {
+		return false;
+	}
+
+	return substr( $str, 0, $prefix_length ) === $prefix;
+}
+
+/**
+ * Answers whether the plugin should provide concat resource URIs
+ * that are relative to a common ancestor directory. Assuming a common ancestor
+ * allows us to skip resolving resource URIs to filesystem paths later on.
+ */
+function page_optimize_has_resource_base_path() {
+	return defined( 'PAGE_OPTIMIZE_RESOURCE_BASE_PATH' ) && file_exists( PAGE_OPTIMIZE_RESOURCE_BASE_PATH );
+}
+
+/**
+ * Get a filesystem path relative to a configured resource base path.
+ * Assuming a common ancestor allows us to skip resolving resource URIs
+ * to filesystem paths later on.
+ */
+function page_optimize_remove_resource_base_path( $original_fs_path ) {
+	if ( page_optimize_has_resource_base_path() ) {
+		$prefix = trailingslashit( PAGE_OPTIMIZE_RESOURCE_BASE_PATH );
+		if ( page_optimize_starts_with( $prefix, $original_fs_path ) ) {
+			$new_path = substr( $original_fs_path, strlen( $prefix ) );
+		}
+	}
+
+	if ( empty( $new_path ) ) {
+		$new_path = '/page-optimize-resource-outside-base-path/' . basename( $original_fs_path );
+	}
+	return $new_path;
+}
+
 function page_optimize_init() {
 	// Bail if we're in customizer
 	global $wp_customize;

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -200,7 +200,7 @@ function page_optimize_starts_with( $prefix, $str ) {
  * that are relative to a common ancestor directory. Assuming a common ancestor
  * allows us to skip resolving resource URIs to filesystem paths later on.
  */
-function page_optimize_has_concat_base_dir() {
+function page_optimize_use_concat_base_dir() {
 	return defined( 'PAGE_OPTIMIZE_CONCAT_BASE_DIR' ) && file_exists( PAGE_OPTIMIZE_CONCAT_BASE_DIR );
 }
 
@@ -210,7 +210,7 @@ function page_optimize_has_concat_base_dir() {
  * resolving resource URIs to filesystem paths later on.
  */
 function page_optimize_remove_concat_base_prefix( $original_fs_path ) {
-	if ( page_optimize_has_concat_base_dir() ) {
+	if ( page_optimize_use_concat_base_dir() ) {
 		$prefix = trailingslashit( PAGE_OPTIMIZE_CONCAT_BASE_DIR );
 		if ( page_optimize_starts_with( $prefix, $original_fs_path ) ) {
 			$new_path = substr( $original_fs_path, strlen( $prefix ) );

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -210,17 +210,26 @@ function page_optimize_use_concat_base_dir() {
  * resolving resource URIs to filesystem paths later on.
  */
 function page_optimize_remove_concat_base_prefix( $original_fs_path ) {
-	if ( page_optimize_use_concat_base_dir() ) {
-		$prefix = trailingslashit( PAGE_OPTIMIZE_CONCAT_BASE_DIR );
-		if ( page_optimize_starts_with( $prefix, $original_fs_path ) ) {
-			$new_path = substr( $original_fs_path, strlen( $prefix ) );
-		}
+	// Always check longer path first
+	if ( strlen( PAGE_OPTIMIZE_ABSPATH ) > strlen( PAGE_OPTIMIZE_CONCAT_BASE_DIR ) ) {
+		$longer_path = PAGE_OPTIMIZE_ABSPATH;
+		$shorter_path = PAGE_OPTIMIZE_CONCAT_BASE_DIR;
+	} else {
+		$longer_path = PAGE_OPTIMIZE_CONCAT_BASE_DIR;
+		$shorter_path = PAGE_OPTIMIZE_ABSPATH;
 	}
 
-	if ( empty( $new_path ) ) {
-		$new_path = '/page-optimize-resource-outside-base-path/' . basename( $original_fs_path );
+	$prefix_abspath = trailingslashit( $longer_path );
+	if ( page_optimize_starts_with( $prefix_abspath, $original_fs_path ) ) {
+		return substr( $original_fs_path, strlen( $prefix_abspath ) );
 	}
-	return $new_path;
+
+	$prefix_basedir = trailingslashit( $shorter_path );
+	if ( page_optimize_starts_with( $prefix_basedir, $original_fs_path ) ) {
+		return substr( $original_fs_path, strlen( $prefix_basedir ) );
+	}
+
+	return '/page-optimize-resource-outside-base-path/' . basename( $original_fs_path );
 }
 
 function page_optimize_init() {

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -4,7 +4,7 @@ Plugin Name: Page Optimize
 Plugin URI: https://wordpress.org/plugins/page-optimize/
 Description: Optimizes JS and CSS for faster page load and render in the browser.
 Author: Automattic
-Version: 0.3.2
+Version: 0.3.3
 Author URI: http://automattic.com/
 */
 
@@ -224,9 +224,9 @@ function page_optimize_remove_concat_base_prefix( $original_fs_path ) {
 }
 
 function page_optimize_init() {
-	// Bail if we're in customizer
+	// Bail if we're in wp-admin or customizer
 	global $wp_customize;
-	if ( isset( $wp_customize ) ) {
+	if ( is_admin() || isset( $wp_customize ) ) {
 		return;
 	}
 

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -229,6 +229,7 @@ function page_optimize_remove_concat_base_prefix( $original_fs_path ) {
 		return substr( $original_fs_path, strlen( $prefix_basedir ) );
 	}
 
+	// If we end up here, this is a resource we shouldn't have tried to concat in the first place
 	return '/page-optimize-resource-outside-base-path/' . basename( $original_fs_path );
 }
 

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -196,8 +196,8 @@ function page_optimize_starts_with( $prefix, $str ) {
  * that are relative to a common ancestor directory. Assuming a common ancestor
  * allows us to skip resolving resource URIs to filesystem paths later on.
  */
-function page_optimize_has_resource_base_path() {
-	return defined( 'PAGE_OPTIMIZE_RESOURCE_BASE_PATH' ) && file_exists( PAGE_OPTIMIZE_RESOURCE_BASE_PATH );
+function page_optimize_has_resource_base_dir() {
+	return defined( 'PAGE_OPTIMIZE_RESOURCE_BASE_DIR' ) && file_exists( PAGE_OPTIMIZE_RESOURCE_BASE_DIR );
 }
 
 /**
@@ -205,9 +205,9 @@ function page_optimize_has_resource_base_path() {
  * Assuming a common ancestor allows us to skip resolving resource URIs
  * to filesystem paths later on.
  */
-function page_optimize_remove_resource_base_path( $original_fs_path ) {
-	if ( page_optimize_has_resource_base_path() ) {
-		$prefix = trailingslashit( PAGE_OPTIMIZE_RESOURCE_BASE_PATH );
+function page_optimize_remove_resource_base_prefix( $original_fs_path ) {
+	if ( page_optimize_has_resource_base_dir() ) {
+		$prefix = trailingslashit( PAGE_OPTIMIZE_RESOURCE_BASE_DIR );
 		if ( page_optimize_starts_with( $prefix, $original_fs_path ) ) {
 			$new_path = substr( $original_fs_path, strlen( $prefix ) );
 		}

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -224,9 +224,9 @@ function page_optimize_remove_concat_base_prefix( $original_fs_path ) {
 }
 
 function page_optimize_init() {
-	// Bail if we're in wp-admin or customizer
+	// Bail if we're in customizer
 	global $wp_customize;
-	if ( is_admin() || isset( $wp_customize ) ) {
+	if ( isset( $wp_customize ) ) {
 		return;
 	}
 

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -13,8 +13,8 @@ if ( ! defined( 'PAGE_OPTIMIZE_CACHE_DIR' ) ) {
 	define( 'PAGE_OPTIMIZE_CACHE_DIR', WP_CONTENT_DIR . '/cache/page_optimize' );
 }
 
-if ( ! defined( 'PAGE_OPTIMIZE_SITE_ROOT_DIR' ) ) {
-	define( 'PAGE_OPTIMIZE_SITE_ROOT_DIR', ABSPATH );
+if ( ! defined( 'PAGE_OPTIMIZE_DEFAULT_RESOURCE_ROOT_DIR' ) ) {
+	define( 'PAGE_OPTIMIZE_DEFAULT_RESOURCE_ROOT_DIR', ABSPATH );
 }
 
 define( 'PAGE_OPTIMIZE_CRON_CACHE_CLEANUP_JOB', 'page_optimize_cron_cache_cleanup' );
@@ -200,18 +200,18 @@ function page_optimize_starts_with( $prefix, $str ) {
  * that are relative to a common ancestor directory. Assuming a common ancestor
  * allows us to skip resolving resource URIs to filesystem paths later on.
  */
-function page_optimize_has_resource_base_dir() {
-	return defined( 'PAGE_OPTIMIZE_RESOURCE_BASE_DIR' ) && file_exists( PAGE_OPTIMIZE_RESOURCE_BASE_DIR );
+function page_optimize_has_concat_base_dir() {
+	return defined( 'PAGE_OPTIMIZE_CONCAT_BASE_DIR' ) && file_exists( PAGE_OPTIMIZE_CONCAT_BASE_DIR );
 }
 
 /**
- * Get a filesystem path relative to a configured resource base path.
- * Assuming a common ancestor allows us to skip resolving resource URIs
- * to filesystem paths later on.
+ * Get a filesystem path relative to a configured base path for resources
+ * that will be concatenated. Assuming a common ancestor allows us to skip
+ * resolving resource URIs to filesystem paths later on.
  */
-function page_optimize_remove_resource_base_prefix( $original_fs_path ) {
-	if ( page_optimize_has_resource_base_dir() ) {
-		$prefix = trailingslashit( PAGE_OPTIMIZE_RESOURCE_BASE_DIR );
+function page_optimize_remove_concat_base_prefix( $original_fs_path ) {
+	if ( page_optimize_has_concat_base_dir() ) {
+		$prefix = trailingslashit( PAGE_OPTIMIZE_CONCAT_BASE_DIR );
 		if ( page_optimize_starts_with( $prefix, $original_fs_path ) ) {
 			$new_path = substr( $original_fs_path, strlen( $prefix ) );
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: performance
 Requires at least: 5.3
 Tested up to: 5.3
 Requires PHP: 7.2
-Stable tag: 0.3.2
+Stable tag: 0.3.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/service.php
+++ b/service.php
@@ -290,8 +290,8 @@ function page_optimize_get_path( $uri ) {
 		page_optimize_status_exit( 400 );
 	}
 
-	if ( defined( 'PAGE_OPTIMIZE_RESOURCE_BASE_PATH' ) ) {
-		$path = realpath( PAGE_OPTIMIZE_RESOURCE_BASE_PATH . "/$uri" );
+	if ( defined( 'PAGE_OPTIMIZE_RESOURCE_BASE_DIR' ) ) {
+		$path = realpath( PAGE_OPTIMIZE_RESOURCE_BASE_DIR . "/$uri" );
 	} else {
 		if ( empty( $dependency_path_mapping ) ) {
 			require_once __DIR__ . '/dependency-path-mapping.php';

--- a/service.php
+++ b/service.php
@@ -87,7 +87,6 @@ function page_optimize_build_output() {
 	ob_start( 'ob_gzhandler' );
 
 	require_once __DIR__ . '/cssmin/cssmin.php';
-	require_once __DIR__ . '/utils.php';
 
 	/* Config */
 	$concat_max_files = 150;
@@ -193,7 +192,7 @@ function page_optimize_build_output() {
 			$dirpath = $subdir_path_prefix . dirname( $uri );
 
 			// url(relative/path/to/file) -> url(/absolute/and/not/relative/path/to/file)
-			$buf = Page_Optimize_Utils::relative_path_replace( $buf, $dirpath );
+			$buf = page_optimize_relative_path_replace( $buf, $dirpath );
 
 			// AlphaImageLoader(...src='relative/path/to/file'...) -> AlphaImageLoader(...src='/absolute/path/to/file'...)
 			$buf = preg_replace(
@@ -277,6 +276,17 @@ function page_optimize_get_mime_type( $file ) {
 	$ext = substr( $file, $lastdot_pos + 1 );
 
 	return isset( $page_optimize_types[ $ext ] ) ? $page_optimize_types[ $ext ] : false;
+}
+
+function page_optimize_relative_path_replace( $buf, $dirpath ) {
+	// url(relative/path/to/file) -> url(/absolute/and/not/relative/path/to/file)
+	$buf = preg_replace(
+		'/(:?\s*url\s*\()\s*(?:\'|")?\s*([^\/\'"\s\)](?:(?<!data:|http:|https:|[\(\'"]#|%23).)*)[\'"\s]*\)/isU',
+		'$1' . ( $dirpath == '/' ? '/' : $dirpath . '/' ) . '$2)',
+		$buf
+	);
+
+	return $buf;
 }
 
 function page_optimize_get_path( $uri ) {

--- a/service.php
+++ b/service.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once __DIR__ . '/dependency-path-mapping.php';
-
 $page_optimize_types = array(
 	'css' => 'text/css',
 	'js' => 'application/javascript'
@@ -66,10 +64,11 @@ function page_optimize_service_request() {
 	}
 
 	$output = page_optimize_build_output();
-	// TODO: It seems insecure to indiscriminately cache and send headers. Cache only specific headers.
-	$meta   = array( 'headers' => headers_list() );
 
 	if ( $use_cache ) {
+		// TODO: It seems insecure to indiscriminately cache and send headers. Cache only specific headers.
+		$meta   = array( 'headers' => headers_list() );
+
 		file_put_contents( $cache_file, $output );
 		file_put_contents( $cache_file_meta, json_encode( $meta ) );
 	}
@@ -282,9 +281,6 @@ function page_optimize_get_mime_type( $file ) {
 
 function page_optimize_get_path( $uri ) {
 	static $dependency_path_mapping;
-	if ( empty( $dependency_path_mapping ) ) {
-		$dependency_path_mapping = new Page_Optimize_Dependency_Path_Mapping();
-	}
 
 	if ( ! strlen( $uri ) ) {
 		page_optimize_status_exit( 400 );
@@ -294,7 +290,16 @@ function page_optimize_get_path( $uri ) {
 		page_optimize_status_exit( 400 );
 	}
 
-	$path = $dependency_path_mapping->uri_path_to_fs_path( $uri );
+	if ( defined( 'PAGE_OPTIMIZE_RESOURCE_BASE_PATH' ) ) {
+		$path = realpath( PAGE_OPTIMIZE_RESOURCE_BASE_PATH . "/$uri" );
+	} else {
+		if ( empty( $dependency_path_mapping ) ) {
+			require_once __DIR__ . '/dependency-path-mapping.php';
+			$dependency_path_mapping = new Page_Optimize_Dependency_Path_Mapping();
+		}
+		$path = $dependency_path_mapping->uri_path_to_fs_path( $uri );
+	}
+
 	if ( false === $path ) {
 		page_optimize_status_exit( 404 );
 	}

--- a/service.php
+++ b/service.php
@@ -66,8 +66,7 @@ function page_optimize_service_request() {
 	$output = page_optimize_build_output();
 
 	if ( $use_cache ) {
-		// TODO: It seems insecure to indiscriminately cache and send headers. Cache only specific headers.
-		$meta   = array( 'headers' => headers_list() );
+		$meta = array( 'headers' => headers_list() );
 
 		file_put_contents( $cache_file, $output );
 		file_put_contents( $cache_file_meta, json_encode( $meta ) );

--- a/service.php
+++ b/service.php
@@ -290,8 +290,8 @@ function page_optimize_get_path( $uri ) {
 		page_optimize_status_exit( 400 );
 	}
 
-	if ( defined( 'PAGE_OPTIMIZE_RESOURCE_BASE_DIR' ) ) {
-		$path = realpath( PAGE_OPTIMIZE_RESOURCE_BASE_DIR . "/$uri" );
+	if ( defined( 'PAGE_OPTIMIZE_CONCAT_BASE_DIR' ) ) {
+		$path = realpath( PAGE_OPTIMIZE_CONCAT_BASE_DIR . "/$uri" );
 	} else {
 		if ( empty( $dependency_path_mapping ) ) {
 			require_once __DIR__ . '/dependency-path-mapping.php';

--- a/service.php
+++ b/service.php
@@ -301,7 +301,13 @@ function page_optimize_get_path( $uri ) {
 	}
 
 	if ( defined( 'PAGE_OPTIMIZE_CONCAT_BASE_DIR' ) ) {
-		$path = realpath( PAGE_OPTIMIZE_CONCAT_BASE_DIR . "/$uri" );
+		if ( file_exists( PAGE_OPTIMIZE_CONCAT_BASE_DIR . "/$uri" ) ) {
+			$path = realpath( PAGE_OPTIMIZE_CONCAT_BASE_DIR . "/$uri" );
+		}
+
+		if ( empty( $path ) && file_exists( PAGE_OPTIMIZE_ABSPATH . "/$uri" ) ) {
+			$path = realpath( PAGE_OPTIMIZE_ABSPATH . "/$uri" );
+		}
 	} else {
 		if ( empty( $dependency_path_mapping ) ) {
 			require_once __DIR__ . '/dependency-path-mapping.php';

--- a/utils.php
+++ b/utils.php
@@ -1,17 +1,6 @@
 <?php
 
 class Page_Optimize_Utils {
-	public static function relative_path_replace( $buf, $dirpath ) {
-		// url(relative/path/to/file) -> url(/absolute/and/not/relative/path/to/file)
-		$buf = preg_replace(
-			'/(:?\s*url\s*\()\s*(?:\'|")?\s*([^\/\'"\s\)](?:(?<!data:|http:|https:|[\(\'"]#|%23).)*)[\'"\s]*\)/isU',
-			'$1' . ( $dirpath == '/' ? '/' : $dirpath . '/' ) . '$2)',
-			$buf
-		);
-
-		return $buf;
-	}
-
 	public static function cache_bust_mtime( $path, $siteurl ) {
 		static $dependency_path_mapping;
 


### PR DESCRIPTION
To increase performance, we are updating our concat service to run without loading WordPress. For this to work, we need to provide real FS paths to the concat script rather than WordPress URIs that need WordPress constants to properly resolve.

By default, we will continue to resolve WordPress resource URIs in the concat service, but we will work from real FS paths when the following constants are defined.

## PAGE_OPTIMIZE_CONCAT_BASE_DIR

The deepest common ancestor of all resources' filesystem paths. When defined, this will be used as the base directory for paths to concatenated resources.

For our sites, this will be `define( 'PAGE_OPTIMIZE_CONCAT_BASE_DIR', '/srv/htdocs' )`.

## PAGE_OPTIMIZE_ABSPATH

Some dependencies have paths based on ABSPATH, and page-optimize needs to know ABSPATH to determine their absolute filesystem path. But on our sites, ABSPATH points to a completely separate directory branch than the plugin and content directories.
ABSPATH = `/wordpress/core/5.3.2`
WP_CONTENT_DIR = `/srv/htdocs/wp-content`
WP_PLUGIN_DIR = `/srv/htdocs/wp-content/plugins`

This interferes with our plan to `define( 'PAGE_OPTIMIZE_CONCAT_BASE_DIR', '/srv/htdocs' )` because the ABSPATH-based paths resolve outside of `/srv/htdocs` under `/wordpress/core/5.3.2`.

But we have some hope because we symlink `/wordpress/core/5.3.2` as `/srv/htdocs/__wp__`, a path under `/srv/htdocs`. This enables us to add a workaround. If we take the dependencies based on `/wordpress/core/5.3.2` (ABSPATH) and base them on `/srv/htdocs/__wp__` instead, all our resource paths will be based on `/srv/htdocs` and will resolve properly when we attempt to concatenate them.

We can do this using `define( 'PAGE_OPTIMIZE_ABSPATH', '/srv/htdocs/__wp__' )`.