### PR TITLE
Limit cached headers

### DIFF
--- a/page-optimize.php
+++ b/page-optimize.php
@@ -4,7 +4,7 @@ Plugin Name: Page Optimize
 Plugin URI: https://wordpress.org/plugins/page-optimize/
 Description: Optimizes JS and CSS for faster page load and render in the browser.
 Author: Automattic
-Version: 0.4.0
+Version: 0.4.1
 Author URI: http://automattic.com/
 */
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: performance
 Requires at least: 5.3
 Tested up to: 5.3
 Requires PHP: 7.2
-Stable tag: 0.4.0
+Stable tag: 0.4.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/service.php
+++ b/service.php
@@ -63,25 +63,22 @@ function page_optimize_service_request() {
 		}
 	}
 
-	list(
-		'output' => $output,
-		'headers' => $headers,
-	) = page_optimize_build_output();
+	$output = page_optimize_build_output();
+	$content = $output['content'];
+	$headers = $output['headers'];
 
 	foreach( $headers as $header ) {
 		header( $header );
 	}
 	header( 'X-Page-Optimize: uncached' );
 	header( 'Cache-Control: max-age=' . 31536000 );
-	header( 'ETag: "' . md5( $output ) . '"' );
+	header( 'ETag: "' . md5( $content ) . '"' );
 
-	echo $output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- We need to trust this unfortunately.
+	echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- We need to trust this unfortunately.
 
 	if ( $use_cache ) {
-		$meta = array( 'headers' => $headers );
-
-		file_put_contents( $cache_file, $output );
-		file_put_contents( $cache_file_meta, json_encode( $meta ) );
+		file_put_contents( $cache_file, $content );
+		file_put_contents( $cache_file_meta, json_encode( array( 'headers' => $headers ) ) );
 	}
 
 	die();
@@ -263,11 +260,10 @@ function page_optimize_build_output() {
 	);
 
 	echo $pre_output . $output;
-	$complete_output = ob_get_clean();
 
 	return array(
 		'headers' => $headers,
-		'output' => $complete_output,
+		'content' => ob_get_clean(),
 	);
 }
 


### PR DESCRIPTION
Prior to this change, we cached all headers sent before the concat
service responds. In most cases, that would be fine because the service
responds very early to the request, but it is technically possible for
another sensitive header to be added prior to response and cached
for sharing with other requestors.

This change removes that possibility by only caching a specific set of
headers.