### PR TITLE
Don't `gzip` in PHP, and add constant for CSS minification

### DIFF
--- a/page-optimize.php
+++ b/page-optimize.php
@@ -4,7 +4,7 @@ Plugin Name: Page Optimize
 Plugin URI: https://wordpress.org/plugins/page-optimize/
 Description: Optimizes JS and CSS for faster page load and render in the browser.
 Author: Automattic
-Version: 0.4.2
+Version: 0.4.3
 Author URI: http://automattic.com/
 */
 

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -8,13 +8,6 @@ Version: 0.4.2
 Author URI: http://automattic.com/
 */
 
-// Page Optimize setup
-define( 'PAGE_OPTIMIZE_CACHE_DIR', false ); // Disable cache
-
-// paths so we can run service.php w/o WP
-define( 'PAGE_OPTIMIZE_CONCAT_BASE_DIR', '/srv/htdocs' );
-define( 'PAGE_OPTIMIZE_ABSPATH', PAGE_OPTIMIZE_CONCAT_BASE_DIR . '/__wp__' );
-
 // Default cache directory
 if ( ! defined( 'PAGE_OPTIMIZE_CACHE_DIR' ) ) {
 	define( 'PAGE_OPTIMIZE_CACHE_DIR', WP_CONTENT_DIR . '/cache/page_optimize' );
@@ -22,6 +15,10 @@ if ( ! defined( 'PAGE_OPTIMIZE_CACHE_DIR' ) ) {
 
 if ( ! defined( 'PAGE_OPTIMIZE_ABSPATH' ) ) {
 	define( 'PAGE_OPTIMIZE_ABSPATH', ABSPATH );
+}
+
+if ( ! defined( 'PAGE_OPTIMIZE_CSS_MINIFY' ) ) {
+	define( 'PAGE_OPTIMIZE_CSS_MINIFY', false );
 }
 
 define( 'PAGE_OPTIMIZE_CRON_CACHE_CLEANUP_JOB', 'page_optimize_cron_cache_cleanup' );

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -28,7 +28,6 @@ define( 'PAGE_OPTIMIZE_CRON_CACHE_CLEANUP_JOB', 'page_optimize_cron_cache_cleanu
 // TODO: Make concat URL dir configurable
 if ( isset( $_SERVER['REQUEST_URI'] ) && '/_static/' === substr( $_SERVER['REQUEST_URI'], 0, 9 ) ) {
 	require_once __DIR__ . '/service.php';
-	page_optimize_service_request();
 	exit;
 }
 

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -8,6 +8,13 @@ Version: 0.4.2
 Author URI: http://automattic.com/
 */
 
+// Page Optimize setup
+define( 'PAGE_OPTIMIZE_CACHE_DIR', false ); // Disable cache
+
+// paths so we can run service.php w/o WP
+define( 'PAGE_OPTIMIZE_CONCAT_BASE_DIR', '/srv/htdocs' );
+define( 'PAGE_OPTIMIZE_ABSPATH', PAGE_OPTIMIZE_CONCAT_BASE_DIR . '/__wp__' );
+
 // Default cache directory
 if ( ! defined( 'PAGE_OPTIMIZE_CACHE_DIR' ) ) {
 	define( 'PAGE_OPTIMIZE_CACHE_DIR', WP_CONTENT_DIR . '/cache/page_optimize' );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: performance
 Requires at least: 5.3
 Tested up to: 5.3
 Requires PHP: 7.2
-Stable tag: 0.4.2
+Stable tag: 0.4.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -33,6 +33,12 @@ To change the cache location, set this constant to the absolute filesystem path 
 
 To disable caching, set this constant to `false`. Please note that disabling Page Optimize caching may negatively impact performance unless you are caching elsewhere.
 
+= PAGE_OPTIMIZE_CSS_MINIFY =
+
+Page Optimize has CSS Minification capabilities which are off by default.
+
+If you're using caching, and not minifying CSS elsewhere, it is recommended to enable it by setting it to `true`.
+
 == Testing ==
 
 To test features without enabling them for the entire site, you may append query params to a WordPress post or page URL. For example, to test enabling JavaScript concatenation for `https://example.com/blog/`, you can use the URL `https://example.com/blog/?concat-js=1`.

--- a/service.php
+++ b/service.php
@@ -51,14 +51,11 @@ function page_optimize_service_request() {
 
 			$etag = '"' . md5( file_get_contents( $cache_file ) ) . '"';
 
-			ob_start();
 			header( 'X-Page-Optimize: cached' );
 			header( 'Cache-Control: max-age=' . 31536000 );
 			header( 'ETag: ' . $etag );
 
 			echo file_get_contents( $cache_file ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- We need to trust this unfortunately.
-			$output = ob_get_clean();
-			echo $output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- We need to trust this unfortunately.
 			die();
 		}
 	}
@@ -86,7 +83,6 @@ function page_optimize_service_request() {
 
 function page_optimize_build_output() {
 	global $page_optimize_types;
-	ob_start();
 
 	require_once __DIR__ . '/cssmin/cssmin.php';
 
@@ -265,11 +261,9 @@ function page_optimize_build_output() {
 		"Content-Type: $mime_type",
 	);
 
-	echo $pre_output . $output;
-
 	return array(
 		'headers' => $headers,
-		'content' => ob_get_clean(),
+		'content' => $pre_output . $output(),
 	);
 }
 

--- a/service.php
+++ b/service.php
@@ -51,7 +51,7 @@ function page_optimize_service_request() {
 
 			$etag = '"' . md5( file_get_contents( $cache_file ) ) . '"';
 
-			ob_start( 'ob_gzhandler' );
+			ob_start();
 			header( 'X-Page-Optimize: cached' );
 			header( 'Cache-Control: max-age=' . 31536000 );
 			header( 'ETag: ' . $etag );
@@ -86,7 +86,7 @@ function page_optimize_service_request() {
 
 function page_optimize_build_output() {
 	global $page_optimize_types;
-	ob_start( 'ob_gzhandler' );
+	ob_start();
 
 	require_once __DIR__ . '/cssmin/cssmin.php';
 
@@ -243,7 +243,7 @@ function page_optimize_build_output() {
 				);
 			}
 
-			$buf = $css_minify->run( $buf );
+			//$buf = $css_minify->run( $buf );
 		}
 
 		if ( $page_optimize_types['js'] === $mime_type ) {

--- a/service.php
+++ b/service.php
@@ -308,11 +308,9 @@ function page_optimize_get_path( $uri ) {
 	}
 
 	if ( defined( 'PAGE_OPTIMIZE_CONCAT_BASE_DIR' ) ) {
-		if ( file_exists( PAGE_OPTIMIZE_CONCAT_BASE_DIR . "/$uri" ) ) {
-			$path = realpath( PAGE_OPTIMIZE_CONCAT_BASE_DIR . "/$uri" );
-		}
+		$path = realpath( PAGE_OPTIMIZE_CONCAT_BASE_DIR . "/$uri" );
 
-		if ( empty( $path ) && file_exists( PAGE_OPTIMIZE_ABSPATH . "/$uri" ) ) {
+		if ( false === $path ) {
 			$path = realpath( PAGE_OPTIMIZE_ABSPATH . "/$uri" );
 		}
 	} else {

--- a/service.php
+++ b/service.php
@@ -152,7 +152,11 @@ function page_optimize_build_output() {
 	$pre_output = '';
 	$output = '';
 
-	$css_minify = new tubalmartin\CssMin\Minifier;
+	$should_minify_css = defined( 'PAGE_OPTIMIZE_CSS_MINIFY' ) && ! empty( PAGE_OPTIMIZE_CSS_MINIFY );
+
+	if ( $should_minify_css ) {
+		$css_minify = new tubalmartin\CssMin\Minifier;
+	}
 
 	foreach ( $args as $uri ) {
 		$fullpath = page_optimize_get_path( $uri );
@@ -243,7 +247,9 @@ function page_optimize_build_output() {
 				);
 			}
 
-			//$buf = $css_minify->run( $buf );
+			if ( $should_minify_css ) {
+				$buf = $css_minify->run( $buf );
+			}
 		}
 
 		if ( $page_optimize_types['js'] === $mime_type ) {

--- a/service.php
+++ b/service.php
@@ -143,7 +143,7 @@ function page_optimize_build_output() {
 
 	$last_modified = 0;
 	$pre_output = '';
-	$output = '';
+	ob_start();
 
 	$should_minify_css = defined( 'PAGE_OPTIMIZE_CSS_MINIFY' ) && ! empty( PAGE_OPTIMIZE_CSS_MINIFY );
 
@@ -246,11 +246,14 @@ function page_optimize_build_output() {
 		}
 
 		if ( $page_optimize_types['js'] === $mime_type ) {
-			$output .= "$buf;\n";
+			echo "$buf;\n";
 		} else {
-			$output .= "$buf";
+			echo "$buf";
 		}
 	}
+
+	$output = ob_get_contents();
+	ob_end_clean();
 
 	$headers = array(
 		'Last-Modified: ' . gmdate( 'D, d M Y H:i:s', $last_modified ) . ' GMT',

--- a/service.php
+++ b/service.php
@@ -5,9 +5,6 @@ $page_optimize_types = array(
 	'js' => 'application/javascript'
 );
 
-// TODO: Provide a settings button to clear the cache
-// TODO: Should we provide a default at all? Is this a reasonable default?
-
 function page_optimize_service_request() {
 	$use_cache = defined( 'PAGE_OPTIMIZE_CACHE_DIR' ) && ! empty( PAGE_OPTIMIZE_CACHE_DIR );
 	if ( $use_cache && ! is_dir( PAGE_OPTIMIZE_CACHE_DIR ) && ! mkdir( PAGE_OPTIMIZE_CACHE_DIR, 0775, true ) ) {
@@ -327,3 +324,5 @@ function page_optimize_get_path( $uri ) {
 
 	return $path;
 }
+
+page_optimize_service_request();

--- a/service.php
+++ b/service.php
@@ -263,7 +263,7 @@ function page_optimize_build_output() {
 
 	return array(
 		'headers' => $headers,
-		'content' => $pre_output . $output(),
+		'content' => $pre_output . $output,
 	);
 }
 

--- a/service.php
+++ b/service.php
@@ -143,7 +143,7 @@ function page_optimize_build_output() {
 
 	$last_modified = 0;
 	$pre_output = '';
-	ob_start();
+	$output = '';
 
 	$should_minify_css = defined( 'PAGE_OPTIMIZE_CSS_MINIFY' ) && ! empty( PAGE_OPTIMIZE_CSS_MINIFY );
 
@@ -246,14 +246,11 @@ function page_optimize_build_output() {
 		}
 
 		if ( $page_optimize_types['js'] === $mime_type ) {
-			echo "$buf;\n";
+			$output .= "$buf;\n";
 		} else {
-			echo "$buf";
+			$output .= "$buf";
 		}
 	}
-
-	$output = ob_get_contents();
-	ob_end_clean();
 
 	$headers = array(
 		'Last-Modified: ' . gmdate( 'D, d M Y H:i:s', $last_modified ) . ' GMT',


### PR DESCRIPTION
- `gzip` in PHP slows stuff down a bit. Simply don't do this. Any web server can handle this better.
- also remove the output buffering, no need for that anymore
- CSS Minification can sometimes slow things down significantly. Add constant to enable/disable.