### PR TITLE
No need to queue cache cleanup if not using cache

### DIFF
--- a/page-optimize.php
+++ b/page-optimize.php
@@ -31,8 +31,8 @@ if ( isset( $_SERVER['REQUEST_URI'] ) && '/_static/' === substr( $_SERVER['REQUE
 	exit;
 }
 
-function page_optimize_cache_cleanup( $file_age = DAY_IN_SECONDS ) {
-	if ( ! is_dir( PAGE_OPTIMIZE_CACHE_DIR ) ) {
+function page_optimize_cache_cleanup( $cache_folder, $file_age = DAY_IN_SECONDS ) {
+	if ( ! is_dir( $cache_folder ) ) {
 		return;
 	}
 
@@ -41,9 +41,13 @@ function page_optimize_cache_cleanup( $file_age = DAY_IN_SECONDS ) {
 	if ( ! $using_cache ) {
 		$file_age = 0;
 	}
+	// If the cache folder changed when the cleanup runs, purge it
+	if ( $using_cache && $cache_folder !== PAGE_OPTIMIZE_CACHE_DIR ) {
+		$file_age = 0;
+	}
 
 	// Grab all files in the cache directory
-	$cache_files = glob( PAGE_OPTIMIZE_CACHE_DIR . '/page-optimize-cache-*' );
+	$cache_files = glob( $cache_folder . '/page-optimize-cache-*' );
 
 	// Cleanup all files older than $file_age
 	foreach ( $cache_files as $cache_file ) {
@@ -60,9 +64,14 @@ add_action( PAGE_OPTIMIZE_CRON_CACHE_CLEANUP_JOB, 'page_optimize_cache_cleanup' 
 
 // Unschedule cache cleanup, and purge cache directory
 function page_optimize_deactivate() {
-	page_optimize_cache_cleanup( 0 /* max file age in seconds */ );
+	$cache_folder = false;
+	if ( defined( 'PAGE_OPTIMIZE_CACHE_DIR' ) && ! empty( PAGE_OPTIMIZE_CACHE_DIR ) ) {
+		$cache_folder = PAGE_OPTIMIZE_CACHE_DIR;
+	}
 
-	wp_clear_scheduled_hook( PAGE_OPTIMIZE_CRON_CACHE_CLEANUP_JOB );
+	page_optimize_cache_cleanup( $cache_folder, 0 /* max file age in seconds */ );
+
+	wp_clear_scheduled_hook( PAGE_OPTIMIZE_CRON_CACHE_CLEANUP_JOB, [ $cache_folder ] );
 }
 register_deactivation_hook( __FILE__, 'page_optimize_deactivate' );
 
@@ -264,9 +273,13 @@ function page_optimize_init() {
 	}
 
 	// Schedule cache cleanup on init
-	$using_cache = defined( 'PAGE_OPTIMIZE_CACHE_DIR' ) && ! empty( PAGE_OPTIMIZE_CACHE_DIR );
-	if( $using_cache && ! wp_next_scheduled( PAGE_OPTIMIZE_CRON_CACHE_CLEANUP_JOB ) ) {
-		wp_schedule_event( time(), 'daily', PAGE_OPTIMIZE_CRON_CACHE_CLEANUP_JOB );
+	$cache_folder = false;
+	if ( defined( 'PAGE_OPTIMIZE_CACHE_DIR' ) && ! empty( PAGE_OPTIMIZE_CACHE_DIR ) ) {
+		$cache_folder = PAGE_OPTIMIZE_CACHE_DIR;
+	}
+	$args = [ $cache_folder ];
+	if( $cache_folder && false === wp_next_scheduled( PAGE_OPTIMIZE_CRON_CACHE_CLEANUP_JOB, $args ) ) {
+		wp_schedule_event( time(), 'daily', PAGE_OPTIMIZE_CRON_CACHE_CLEANUP_JOB, $args );
 	}
 
 	require_once __DIR__ . '/settings.php';

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -4,7 +4,7 @@ Plugin Name: Page Optimize
 Plugin URI: https://wordpress.org/plugins/page-optimize/
 Description: Optimizes JS and CSS for faster page load and render in the browser.
 Author: Automattic
-Version: 0.4.3
+Version: 0.4.4
 Author URI: http://automattic.com/
 */
 

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -31,7 +31,7 @@ if ( isset( $_SERVER['REQUEST_URI'] ) && '/_static/' === substr( $_SERVER['REQUE
 	exit;
 }
 
-function page_optimize_cache_cleanup( $cache_folder, $file_age = DAY_IN_SECONDS ) {
+function page_optimize_cache_cleanup( $cache_folder = false, $file_age = DAY_IN_SECONDS ) {
 	if ( ! is_dir( $cache_folder ) ) {
 		return;
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: performance
 Requires at least: 5.3
 Tested up to: 5.3
 Requires PHP: 7.2
-Stable tag: 0.4.3
+Stable tag: 0.4.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -49,4 +49,4 @@ Supported query params:
 
 == Changelog ==
 
-* Don't queue the cache cleaning WP Cron job if we aren't caching.
+- Don't queue the cache cleaning WP Cron job if we aren't caching.

--- a/readme.txt
+++ b/readme.txt
@@ -52,3 +52,11 @@ Supported query params:
 = 0.4.4 =
 * Don't queue the cache cleaning WP Cron job if we aren't caching.
 * Cleanup cache if we turned caching off or directory changed.
+
+= 0.4.3 =
+* gzip in PHP slows stuff down a bit. Simply don't do this. Any web server can handle this better.
+* also remove the output buffering, no need for that anymore
+* CSS Minification can sometimes slow things down significantly. Add constant to enable/disable.
+
+= 0.4.2 =
+* Initial release. No changes yet. :)

--- a/readme.txt
+++ b/readme.txt
@@ -49,4 +49,6 @@ Supported query params:
 
 == Changelog ==
 
-- Don't queue the cache cleaning WP Cron job if we aren't caching.
+= 0.4.4 =
+* Don't queue the cache cleaning WP Cron job if we aren't caching.
+* Cleanup cache if we turned caching off or directory changed.

--- a/readme.txt
+++ b/readme.txt
@@ -49,4 +49,4 @@ Supported query params:
 
 == Changelog ==
 
-Initial release. No changes yet. :)
+* Don't queue the cache cleaning WP Cron job if we aren't caching.


### PR DESCRIPTION
- Update the cleanup job to purge the cache if it's disabled when it runs next time.
- Or if the cache directory changed.