### PR TITLE
Mark script load mode as experimental in settings

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -65,7 +65,7 @@ function page_optimize_settings_field_js_load_mode( $args ) {
 		</label>
 
 		<p class="description">
-			<?php _e( 'You can choose the execution mode of the concatenated JavaScript. This option might break your site, so use carefully.', page_optimize_get_text_domain() ); ?>
+			<?php _e( 'You can choose the execution mode of the concatenated JavaScript. <strong>This option might break your site, so use carefully.</strong>', page_optimize_get_text_domain() ); ?>
 		</p>
 	</fieldset>
 	<?php

--- a/settings.php
+++ b/settings.php
@@ -169,7 +169,7 @@ function page_optimize_settings_init() {
 	);
 	add_settings_field(
 		'page_optimize_js_load_mode',
-		__( 'Non-critical script execution mode', page_optimize_get_text_domain() ),
+		__( 'Non-critical script execution mode (experimental)', page_optimize_get_text_domain() ),
 		'page_optimize_settings_field_js_load_mode',
 		'page-optimize',
 		'page_optimize_settings_section'


### PR DESCRIPTION
When talking with @automattic-ian about Page Optimize, I found that I didn't want to recommend use of the script load mode feature at all right now because it can easily break things.

This is a simple PR to add "(experimental)" to the load mode label in settings to hopefully communicate the danger. I know we have "this option might break your site", but I want something a bit stronger.
<img width="832" alt="Screen Shot 2020-03-11 at 12 33 30 AM" src="https://user-images.githubusercontent.com/530877/76393256-6c03f480-6330-11ea-8ef6-f527cac1c607.png">
