### PR TITLE
Reduce interference with script tag filtering

### DIFF
--- a/concat-js.php
+++ b/concat-js.php
@@ -249,10 +249,20 @@ class Page_Optimize_JS_Concat extends WP_Scripts {
 					$load_mode = page_optimize_load_mode_js();
 
 					if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-						echo "<script data-handles='" . esc_attr( $handles ) . "' $load_mode type='text/javascript' src='$href'></script>\n";
+						$tag = "<script data-handles='" . esc_attr( $handles ) . "' $load_mode type='text/javascript' src='$href'></script>\n";
 					} else {
-						echo "<script type='text/javascript' $load_mode src='$href'></script>\n";
+						$tag = "<script type='text/javascript' $load_mode src='$href'></script>\n";
 					}
+
+					if ( is_array( $js_array['handles'] ) && count( $js_array['handles'] ) === 1 ) {
+						// Because we have a single script, let's apply the `script_loader_tag` filter as core does in `do_item()`.
+						// That way, we reduce interfere less with plugin and theme script filtering. For example, without this filter,
+						// there is a case where we block the TwentyTwenty theme from adding async/defer attributes.
+						// https://github.com/Automattic/page-optimize/pull/44
+						$tag = apply_filters( 'script_loader_tag', $tag, $js_array['handles'], $href );
+					}
+
+					echo $tag;
 				}
 
 				if ( isset( $js_array['extras']['after'] ) ) {

--- a/concat-js.php
+++ b/concat-js.php
@@ -259,7 +259,7 @@ class Page_Optimize_JS_Concat extends WP_Scripts {
 						// That way, we reduce interfere less with plugin and theme script filtering. For example, without this filter,
 						// there is a case where we block the TwentyTwenty theme from adding async/defer attributes.
 						// https://github.com/Automattic/page-optimize/pull/44
-						$tag = apply_filters( 'script_loader_tag', $tag, $js_array['handles'], $href );
+						$tag = apply_filters( 'script_loader_tag', $tag, $js_array['handles'][0], $href );
 					}
 
 					echo $tag;

--- a/concat-js.php
+++ b/concat-js.php
@@ -256,7 +256,7 @@ class Page_Optimize_JS_Concat extends WP_Scripts {
 
 					if ( is_array( $js_array['handles'] ) && count( $js_array['handles'] ) === 1 ) {
 						// Because we have a single script, let's apply the `script_loader_tag` filter as core does in `do_item()`.
-						// That way, we reduce interfere less with plugin and theme script filtering. For example, without this filter,
+						// That way, we interfere less with plugin and theme script filtering. For example, without this filter,
 						// there is a case where we block the TwentyTwenty theme from adding async/defer attributes.
 						// https://github.com/Automattic/page-optimize/pull/44
 						$tag = apply_filters( 'script_loader_tag', $tag, $js_array['handles'][0], $href );


### PR DESCRIPTION
When we encounter a single-script concat group, we aren't actually
concatenating, yet because the script is expected to be concatenated,
we handle printing the script rather than relying on the do_item()
method. This means that the core `script_loader_tag` filter is not
applied to the script tag even though it is still a normal,
single-script tag.

@josephscott [recently discovered](https://github.com/Automattic/page-optimize/pull/44/) that this interfere's with
the TwentyTwenty theme adding async/defer attributes to its scripts
even though they are not being concatenated with anything else.

We address this by manually applying the `script_loader_tag` filter
when we are printing the script tag for a single-script concat group.