### PR TITLE
Loading the static when WordPress is in a subdirectory.

### DIFF
--- a/concat-css.php
+++ b/concat-css.php
@@ -39,6 +39,7 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 		$handles = false === $handles ? $this->queue : (array) $handles;
 		$stylesheets = array();
 		$siteurl = apply_filters( 'page_optimize_site_url', $this->base_url );
+		$site_uri_path = page_optimize_get_uri_path( $siteurl );
 
 		$this->all_deps( $handles );
 
@@ -136,7 +137,9 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 					$media = 'all';
 				}
 
-				$stylesheets[ $concat_group ][ $media ][ $handle ] = $css_url_parsed['path'];
+				$css_uri_path = page_optimize_remove_uri_prefix( $site_uri_path, $css_url_parsed['path'] );
+
+				$stylesheets[ $concat_group ][ $media ][ $handle ] = $css_uri_path;
 				$this->done[] = $handle;
 			} else {
 				$stylesheet_group_index ++;
@@ -158,7 +161,7 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 				} elseif ( count( $css ) > 1 ) {
 					$fs_paths = array();
 					foreach ( $css as $css_uri_path ) {
-						$fs_paths[] = $this->dependency_path_mapping->uri_path_to_fs_path( $css_uri_path );
+						$fs_paths[] = $this->dependency_path_mapping->uri_path_to_fs_path( $site_uri_path . $css_uri_path );
 					}
 
 					$mtime = max( array_map( 'filemtime', $fs_paths ) );

--- a/concat-js.php
+++ b/concat-js.php
@@ -59,6 +59,7 @@ class Page_Optimize_JS_Concat extends WP_Scripts {
 		$handles = false === $handles ? $this->queue : (array) $handles;
 		$javascripts = array();
 		$siteurl = apply_filters( 'page_optimize_site_url', $this->base_url );
+		$site_uri_path = page_optimize_get_uri_path( $siteurl );
 		$this->all_deps( $handles );
 		$level = 0;
 
@@ -171,7 +172,9 @@ class Page_Optimize_JS_Concat extends WP_Scripts {
 					$javascripts[ $level ]['type'] = 'concat';
 				}
 
-				$javascripts[ $level ]['paths'][] = $js_url_parsed['path'];
+				$js_uri_path = page_optimize_remove_uri_prefix( $site_uri_path, $js_url_parsed['path'] );
+
+				$javascripts[ $level ]['paths'][] = $js_uri_path;
 				$javascripts[ $level ]['handles'][] = $handle;
 
 			} else {
@@ -211,7 +214,7 @@ class Page_Optimize_JS_Concat extends WP_Scripts {
 				if ( isset( $js_array['paths'] ) && count( $js_array['paths'] ) > 1 ) {
 					$fs_paths = array();
 					foreach ( $js_array['paths'] as $js_url ) {
-						$fs_paths[] = $this->dependency_path_mapping->uri_path_to_fs_path( $js_url );
+						$fs_paths[] = $this->dependency_path_mapping->uri_path_to_fs_path( $site_uri_path . $js_url );
 					}
 
 					$mtime = max( array_map( 'filemtime', $fs_paths ) );

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -26,7 +26,7 @@ define( 'PAGE_OPTIMIZE_CRON_CACHE_CLEANUP_JOB', 'page_optimize_cron_cache_cleanu
 // TODO: Copy tests from nginx-http-concat and/or write them
 
 // TODO: Make concat URL dir configurable
-if ( isset( $_SERVER['REQUEST_URI'] ) && '/_static/' === substr( $_SERVER['REQUEST_URI'], 0, 9 ) ) {
+if ( isset( $_SERVER['REQUEST_URI'] ) && false !== strpos( $_SERVER['REQUEST_URI'], '/_static/??' ) ) {
 	require_once __DIR__ . '/service.php';
 	exit;
 }
@@ -211,6 +211,28 @@ function page_optimize_starts_with( $prefix, $str ) {
 	}
 
 	return substr( $str, 0, $prefix_length ) === $prefix;
+}
+
+/**
+ * Returns the uri path from the url.
+ */
+function page_optimize_get_uri_path( $url ) {
+	$path = trailingslashit( parse_url( $url, PHP_URL_PATH ) );
+	return $path == '/' ? '' : $path;
+}
+
+/**
+ * Removes the path prefix from the uri string.
+ */
+function page_optimize_remove_uri_prefix( $prefix, $uri ) {
+	if ( empty( $prefix ) ) {
+		return $uri;
+	}
+	if ( ! page_optimize_starts_with( $prefix, $uri ) ) {
+		return $uri;
+	}
+
+	return '/' . ltrim( substr( $uri, strlen($prefix) ), '/' );
 }
 
 /**

--- a/service.php
+++ b/service.php
@@ -152,7 +152,7 @@ function page_optimize_build_output() {
 	}
 
 	foreach ( $args as $uri ) {
-		$fullpath = page_optimize_get_path( $uri );
+		$fullpath = page_optimize_get_path( $subdir_path_prefix . $uri );
 
 		if ( ! file_exists( $fullpath ) ) {
 			page_optimize_status_exit( 404 );


### PR DESCRIPTION
When WordPress is installed into a subdirectory this plugin cannot
load static files and breaks the frontend.
This patch adds the site uri path to the generated static links.