### PR TITLE
Bail if we're editing pages with Brizy Editor

### DIFF
--- a/page-optimize.php
+++ b/page-optimize.php
@@ -278,7 +278,7 @@ function page_optimize_bail() {
 	}
 
 	// Bail if we're editing pages in Brizy Editor
-	if ( class_exists( 'Brizy_Editor' ) && ( isset( $_GET[ Brizy_Editor::prefix( '-edit-iframe' ) ] ) || isset( $_GET[ Brizy_Editor::prefix( '-edit' ) ] ) ) ) {
+	if ( class_exists( 'Brizy_Editor' ) && ( method_exists( 'Brizy_Editor', 'prefix' ) ) && ( isset( $_GET[ Brizy_Editor::prefix( '-edit-iframe' ) ] ) || isset( $_GET[ Brizy_Editor::prefix( '-edit' ) ] ) ) ) {
 		return true;
 	}
 

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -278,7 +278,7 @@ function page_optimize_bail() {
 	}
 
 	// Bail if we're editing pages in Brizy Editor
-	if ( class_exists( 'Brizy_Editor' ) && ( method_exists( 'Brizy_Editor', 'prefix' ) ) && ( isset( $_GET[ Brizy_Editor::prefix( '-edit-iframe' ) ] ) || isset( $_GET[ Brizy_Editor::prefix( '-edit' ) ] ) ) ) {
+	if ( class_exists( 'Brizy_Editor' ) && method_exists( 'Brizy_Editor', 'prefix' ) && ( isset( $_GET[ Brizy_Editor::prefix( '-edit-iframe' ) ] ) || isset( $_GET[ Brizy_Editor::prefix( '-edit' ) ] ) ) ) {
 		return true;
 	}
 

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -4,7 +4,7 @@ Plugin Name: Page Optimize
 Plugin URI: https://wordpress.org/plugins/page-optimize/
 Description: Optimizes JS and CSS for faster page load and render in the browser.
 Author: Automattic
-Version: 0.5.0
+Version: 0.5.1
 Author URI: http://automattic.com/
 */
 
@@ -274,6 +274,11 @@ function page_optimize_bail() {
 
 	// Bail if Divi theme is active, and we're in the Divi Front End Builder
 	if ( ! empty( $_GET['et_fb'] ) && 'Divi' === wp_get_theme()->get_template() ) {
+		return true;
+	}
+
+	// Bail if we're editing pages in Brizy Editor
+	if ( class_exists( 'Brizy_Editor' ) && ( isset( $_GET[ Brizy_Editor::prefix( '-edit-iframe' ) ] ) || isset( $_GET[ Brizy_Editor::prefix( '-edit' ) ] ) ) ) {
 		return true;
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -50,7 +50,7 @@ Supported query params:
 == Changelog ==
 
 = 0.5.1 =
-* Bail when editing pages in Brizy Editor
+* Bail when editing pages in Brizy Editor (it errors when JavaScript load mode is `async`).
 
 = 0.5.0 =
 * Apply the `script_loader_tag` filter for scripts that are concatenate-able but have no neighbors to concatenate with. This fixes a case where the TwentyTwenty theme wanted to apply a `defer` attribute to its script but was never given the opportunity.

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: aidvu, bpayton
 Tags: performance
 Requires at least: 5.3
-Tested up to: 5.4
+Tested up to: 5.5.1
 Requires PHP: 7.0
-Stable tag: 0.5.0
+Stable tag: 0.5.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -48,6 +48,9 @@ Supported query params:
 * `load-mode-js` controls how non-critical JavaScript are loaded. Values: 'defer' for [deferred](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-defer), 'async' for [async loading](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-async), any other value indicates the feature should be disabled.
 
 == Changelog ==
+
+= 0.5.1 =
+* Bail when editing pages in Brizy Editor
 
 = 0.5.0 =
 * Apply the `script_loader_tag` filter for scripts that are concatenate-able but have no neighbors to concatenate with. This fixes a case where the TwentyTwenty theme wanted to apply a `defer` attribute to its script but was never given the opportunity.


### PR DESCRIPTION
And bump WP supported version.

Support Thread: https://wordpress.org/support/topic/compatibility-with-brizy-plugin-4/

--------------------------

Steps to reproduce:
- Activate `page-optimize`
- Set JS load mode to `async`
- Install Brizy
- Try to edit a page

Before:
- A bunch of JS errors

After:
- Page edit loads properly