### PR TITLE
Missed @import and @charset statements

### DIFF
--- a/service.php
+++ b/service.php
@@ -141,6 +141,7 @@ function page_optimize_build_output() {
 	}
 	unset( $request_path, $_static_index );
 
+	global $pre_output;
 	$last_modified = 0;
 	$pre_output = '';
 	$output = '';


### PR DESCRIPTION
Hi. We found a bug, and luckily we were able to fix it quickly.

We noticed that our CSS files lose `@import` statements after combining individual files into one common file by this plugin.
While debugging, we noticed that `@charset` statements also get deleted from the final CSS.

The code in file `service.php` has `$pre_output` variable which is defined as local variable inside the `page_optimize_build_output()` function. And inside `page_optimize_build_output()` there is multiple anonymous functions as callbacks for `preg_replace_callback()` Anonymous callbacks uses `global $pre_output` varialble.

So we have multiple functions and the same variable in a different context. Global always means `global` scope, even in a function or a class. And to solve this, you only need to add a `global` keyword before `$pre_output`.