### PR TITLE
Consolidate init and skip optimizing in AMP mode

### DIFF
--- a/concat-css.php
+++ b/concat-css.php
@@ -3,10 +3,6 @@
 require_once __DIR__ . '/dependency-path-mapping.php';
 require_once __DIR__ . '/utils.php';
 
-if ( ! defined( 'ALLOW_GZIP_COMPRESSION' ) ) {
-	define( 'ALLOW_GZIP_COMPRESSION', true );
-}
-
 class Page_Optimize_CSS_Concat extends WP_Styles {
 	private $dependency_path_mapping;
 	private $old_styles;
@@ -211,15 +207,4 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 		$this->old_styles->$key = $value;
 	}
 }
-
-function page_optimize_css_concat_init() {
-	global $wp_styles;
-
-	if ( page_optimize_should_concat_css() ) {
-		$wp_styles = new Page_Optimize_CSS_Concat( $wp_styles );
-		$wp_styles->allow_gzip_compression = ALLOW_GZIP_COMPRESSION;
-	}
-}
-
-add_action( 'init', 'page_optimize_css_concat_init' );
 

--- a/concat-js.php
+++ b/concat-js.php
@@ -3,10 +3,6 @@
 require_once __DIR__ . '/dependency-path-mapping.php';
 require_once __DIR__ . '/utils.php';
 
-if ( ! defined( 'ALLOW_GZIP_COMPRESSION' ) ) {
-	define( 'ALLOW_GZIP_COMPRESSION', true );
-}
-
 class Page_Optimize_JS_Concat extends WP_Scripts {
 	private $dependency_path_mapping;
 	private $old_scripts;
@@ -294,15 +290,4 @@ class Page_Optimize_JS_Concat extends WP_Scripts {
 		$this->old_scripts->$key = $value;
 	}
 }
-
-function page_optimize_js_concat_init() {
-	global $wp_scripts;
-
-	if ( ! is_admin() && ( page_optimize_should_concat_js() || page_optimize_load_mode_js() ) ) {
-		$wp_scripts = new Page_Optimize_JS_Concat( $wp_scripts );
-		$wp_scripts->allow_gzip_compression = ALLOW_GZIP_COMPRESSION;
-	}
-}
-
-add_action( 'init', 'page_optimize_js_concat_init' );
 


### PR DESCRIPTION
This PR consolidates conditional init logic with the goal of cleanly skipping optimization when in AMP mode. It also adds filters for overriding JS or CSS concat and for skipping optimization completely.

I'd rather break some of this up into steps, but for the sake of time since this is a lower priority item, I am keeping it on PR and will be explicitly testing all the changes. I think these changes are safe enough that we will not regret this compromise.