### PR TITLE
Stop leaving misplaced charsets in concat output

### DIFF
--- a/service.php
+++ b/service.php
@@ -203,7 +203,7 @@ function page_optimize_build_output() {
 
 			// The @charset rules must be on top of the output
 			if ( 0 === strpos( $buf, '@charset' ) ) {
-				preg_replace_callback(
+				$buf = preg_replace_callback(
 					'/(?P<charset_rule>@charset\s+[\'"][^\'"]+[\'"];)/i',
 					function ( $match ) {
 						global $pre_output;


### PR DESCRIPTION
Prior to this PR, the result of the `@charset` text replacement was discarded. This lead to `@charset` lines being duplicated rather than moved.

After this change, `@charset` lines are correctly moved -- added to the pre-output buffer and removed from the main output buffer.