### PR TITLE
Stop concat from reordering CSS

### DIFF
--- a/concat-css.php
+++ b/concat-css.php
@@ -43,10 +43,6 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 		$this->all_deps( $handles );
 
 		$stylesheet_group_index = 0;
-		// Merge CSS into a single file
-		$concat_group = 'concat';
-		// Concat group on top (first array element gets processed earlier)
-		$stylesheets[ $concat_group ] = array();
 
 		// Expose items so tests can check concat output against the initial todo items
 		do_action( 'page_optimize_doing_style_items', $this->to_do, $group );
@@ -142,7 +138,14 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 					$media = 'all';
 				}
 
-				$stylesheets[ $concat_group ][ $media ][ $handle ] = $css_url_parsed['path'];
+				if (
+					! isset( $stylesheets[ $stylesheet_group_index ][ $media ][ $handle ] ) ||
+					! is_array( $stylesheets[ $stylesheet_group_index ][ $media ][ $handle ] )
+				) {
+					$stylesheets[ $stylesheet_group_index ][ $media ][ $handle ] = array();
+				}
+
+				$stylesheets[ $stylesheet_group_index ][ $media ][ $handle ] = $css_url_parsed['path'];
 				$this->done[] = $handle;
 			} else {
 				$stylesheet_group_index ++;


### PR DESCRIPTION
CSS rule order matters. Changing the rule order changes which rule wins when there are conflicting rules with the same CSS specificity.

Unfortunately, page-optimize is currently breaking the rule order by placing all concatenated CSS in a single concat group. 

This is particularly evident when there are excluded styles like those for dashicons. Concatenated styles are all placed before concat-excluded styles, even if enqueue order and WordPress dependency resolution says the concat-excluded styles should come earlier.

This PR fixes page-optimize to preserve the order of CSS dependencies registered with WordPress.