### PR TITLE
Page Optimize Bail: Avoid asset concatenation when opening the site editor

### DIFF
--- a/page-optimize.php
+++ b/page-optimize.php
@@ -282,6 +282,12 @@ function page_optimize_bail() {
 		return true;
 	}
 
+	// Bail if we're in the site editor
+	global $_SERVER;
+	if ( str_contains( $_SERVER['QUERY_STRING'], 'page=gutenberg-edit-site' ) ) {
+		return true;
+	}
+
 	return false;
 }
 


### PR DESCRIPTION
## Description
Potentially fixes https://github.com/Automattic/wp-calypso/issues/54459

This is a hotfix to prevent loading an editor reset stylesheet in the Gutenberg Site Editor. We are attempting to merge  changes into [core Gutenberg](https://github.com/WordPress/gutenberg/pull/33522) that will address the underlying bug, at which point the changes made in this PR can be removed.

This PR causes the `page-optimize` plugin to bail if loading assets for the Gutenberg Site Editor.

An alternative hotfix can be found in 738-gh-Automattic/wpcomsh

## Steps to Reproduce
- With a block based theme activated, load the site editor with the page optimize plugin enabled
- Verify that `wp-reset-editor-styles` is not loaded, by searching the page markup for the stylesheet id (`wp-reset-editor-styles-css`) and/or checking to make sure the styles are not applied to `.editor-styles-wrapper` within the iframe
- Also load the post editor to make sure the styles reset continues to load there