### PR TITLE
Fix CSS @import order issues using text/css data URIs

### DIFF
--- a/service.php
+++ b/service.php
@@ -238,10 +238,14 @@ function page_optimize_get_mime_type( $file ) {
 
 function page_optimize_generate_import_from_css_content( $raw_css_content ) {
 	$escaped_css_content = str_replace(
-		array( "\r", "\n", "\\", "'" ),
-		array( "\\D", "\\A", "\\\\", "\\'" ),
+		// TODO: Improve comment
+		// NOTE: It's important to escape existing backslashes first as subsequent replacements insert more of them
+		array( "\\",  "\r",  "\n",  "'",   "#" ),
+		array( "%5C", "%0D", "%0A", "\\'", "%23" ),
 		$raw_css_content
 	);
+	// TODO: Remove this
+	//$escaped_css_content = rawurlencode( $raw_css_content );
 	return "@import url( 'data:text/css,$escaped_css_content' );\n";
 }
 


### PR DESCRIPTION
This PR isolates each concatenated CSS file as an imported data URI like:

```css
@import url( 'data:text/css,body { color: blue; }' );
```

This should allow us to concatenate while preserving the order and application of `@import` and `@charset` rules which have to come at the beginning of a CSS document.

Unfortunately, no IE version appears to support reading CSS this way, but all other browsers I tested appear to support it. Since IE11 is no longer supported by WordPress core, this PR will drop CSS concat support for IE. This should not break IE because we can just skip CSS concatenation rather than using the above technique which breaks things.