### PR TITLE
fix for broken websites when hosted into sub-directory and other path related issues

### DIFF
--- a/concat-css.php
+++ b/concat-css.php
@@ -38,11 +38,9 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 	function do_items( $handles = false, $group = false ) {
 		$handles = false === $handles ? $this->queue : (array) $handles;
 		$stylesheets = array();
-		$siteurl = apply_filters( 'page_optimize_site_url', $this->base_url );
 
 		// get the website base url
-		$url_raw = parse_url( $siteurl );
-		$baseurl = $url_raw['scheme'] . "://" . $url_raw['host'];
+		$siteurl = apply_filters( 'page_optimize_site_url', $this->dependency_path_mapping->base_url );
 
 		$this->all_deps( $handles );
 
@@ -180,9 +178,9 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 						}
 					}
 
-					$href = $siteurl . "/_static/??" . $path_str;
+					$href = $siteurl . $this->dependency_path_mapping->site_subdir_path . "/_static/??" . $path_str;
 				} else {
-					$href = Page_Optimize_Utils::cache_bust_mtime( current( $css ), $baseurl );
+					$href = Page_Optimize_Utils::cache_bust_mtime( current( $css ), $siteurl );
 				}
 
 				$handles = array_keys( $css );

--- a/concat-css.php
+++ b/concat-css.php
@@ -45,12 +45,11 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 		$this->all_deps( $handles );
 
 		// Merge CSS into a single file
-		$concat_group = 'concat';
-
-		// Concat group on top (first array element gets processed earlier)
-		$stylesheets[ $concat_group ] = array();
+		$style_index = 0;
+		$style_group = array();
 
 		foreach ( $this->to_do as $key => $handle ) {
+
 			$obj = $this->registered[ $handle ];
 			$obj->src = apply_filters( 'style_loader_src', $obj->src, $obj->handle );
 
@@ -65,16 +64,18 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 			$css_url_parsed = parse_url( $obj->src );
 			$extra = $obj->extra;
 
-			// Don't concat by default
-			$do_concat = false;
-
 			// Only try to concat static css files
 			if ( false !== strpos( $css_url_parsed['path'], '.css' ) ) {
 				$do_concat = true;
 			} else {
+
 				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 					echo sprintf( "\n<!-- No Concat CSS %s => Maybe Not Static File %s -->\n", esc_html( $handle ), esc_html( $obj->src ) );
 				}
+
+				$style_group['not-static-'. $style_index++ ] = $handle;
+
+				$do_concat = false;
 			}
 
 			// Don't try to concat styles which are loaded conditionally (like IE stuff)
@@ -82,6 +83,8 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 					echo sprintf( "\n<!-- No Concat CSS %s => Has Conditional -->\n", esc_html( $handle ) );
 				}
+
+				$style_group['conditional-'. $style_index++ ] = $handle;
 				$do_concat = false;
 			}
 
@@ -90,6 +93,8 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 					echo sprintf( "\n<!-- No Concat CSS %s => Is RTL -->\n", esc_html( $handle ) );
 				}
+
+				$style_group['rtl-'. $style_index++ ] = $handle;
 				$do_concat = false;
 			}
 
@@ -99,6 +104,8 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 					echo sprintf( "\n<!-- No Concat CSS %s => External URL: %s -->\n", esc_html( $handle ), esc_url( $css_url ) );
 				}
+
+				$style_group['external-'. $style_index++ ] = $handle;
 				$do_concat = false;
 			}
 
@@ -109,6 +116,8 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 					if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 						echo sprintf( "\n<!-- No Concat CSS %s => Invalid Path %s -->\n", esc_html( $handle ), esc_html( $css_realpath ) );
 					}
+
+					$style_group['invalid-'. $style_index++ ] = $handle;
 					$do_concat = false;
 				}
 			}
@@ -117,10 +126,12 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 			$exclude_list = page_optimize_css_exclude_list();
 			foreach ( $exclude_list as $exclude ) {
 				if ( $do_concat && $handle === $exclude ) {
-					$do_concat = false;
 					if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 						echo sprintf( "\n<!-- No Concat CSS %s => Excluded option -->\n", esc_html( $handle ) );
 					}
+
+					$style_group['excluded-'. $style_index++ ] = $handle;
+					$do_concat = false;
 				}
 			}
 
@@ -133,12 +144,15 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 			$do_concat = apply_filters( 'css_do_concat', $do_concat, $handle );
 
 			if ( true === $do_concat ) {
+
+				$style_group[ 'concat-' . $style_index ][] = $handle;
+
 				$media = $obj->args;
 				if ( empty( $media ) ) {
 					$media = 'all';
 				}
 
-				$stylesheets[ $concat_group ][ $media ][ $handle ] = $css_url_parsed['path'];
+				$stylesheets[ 'concat-' . $style_index ][ $media ][ $handle ] = $css_url_parsed['path'];
 				$this->done[] = $handle;
 			} else {
 				if ( $this->do_item( $handle, $group ) ) {
@@ -150,7 +164,7 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 
 		foreach ( $stylesheets as $idx => $stylesheets_group ) {
 			foreach ( $stylesheets_group as $media => $css ) {
-				if ( count( $css ) > 1 ) {
+				if ( !empty( $css ) ) {
 					$fs_paths = array();
 					foreach ( $css as $css_uri_path ) {
 						$fs_paths[] = $this->dependency_path_mapping->uri_path_to_fs_path( $css_uri_path );

--- a/concat-css.php
+++ b/concat-css.php
@@ -44,9 +44,9 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 
 		$this->all_deps( $handles );
 
-		$stylesheet_group_index = 0;
 		// Merge CSS into a single file
 		$concat_group = 'concat';
+
 		// Concat group on top (first array element gets processed earlier)
 		$stylesheets[ $concat_group ] = array();
 

--- a/concat-css.php
+++ b/concat-css.php
@@ -141,23 +141,16 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 				$stylesheets[ $concat_group ][ $media ][ $handle ] = $css_url_parsed['path'];
 				$this->done[] = $handle;
 			} else {
-				$stylesheet_group_index ++;
-				$stylesheets[ $stylesheet_group_index ]['noconcat'][] = $handle;
-				$stylesheet_group_index ++;
+				if ( $this->do_item( $handle, $group ) ) {
+					$this->done[] = $handle;
+				}
 			}
 			unset( $this->to_do[ $key ] );
 		}
 
 		foreach ( $stylesheets as $idx => $stylesheets_group ) {
 			foreach ( $stylesheets_group as $media => $css ) {
-				if ( 'noconcat' == $media ) {
-					foreach ( $css as $handle ) {
-						if ( $this->do_item( $handle, $group ) ) {
-							$this->done[] = $handle;
-						}
-					}
-					continue;
-				} elseif ( count( $css ) > 1 ) {
+				if ( count( $css ) > 1 ) {
 					$fs_paths = array();
 					foreach ( $css as $css_uri_path ) {
 						$fs_paths[] = $this->dependency_path_mapping->uri_path_to_fs_path( $css_uri_path );

--- a/concat-css.php
+++ b/concat-css.php
@@ -40,7 +40,11 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 		$stylesheets = array();
 		$siteurl = apply_filters( 'page_optimize_site_url', $this->base_url );
 
-		$this->all_deps( $handles );
+        // get the website base url
+        $url_raw = parse_url($siteurl);
+        $baseurl = $url_raw['scheme']."://".$url_raw['host'];
+
+        $this->all_deps( $handles );
 
 		$stylesheet_group_index = 0;
 		// Merge CSS into a single file
@@ -178,7 +182,7 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 
 					$href = $siteurl . "/_static/??" . $path_str;
 				} else {
-					$href = Page_Optimize_Utils::cache_bust_mtime( current( $css ), $siteurl );
+					$href = Page_Optimize_Utils::cache_bust_mtime( current( $css ), $baseurl );
 				}
 
 				$handles = array_keys( $css );

--- a/concat-css.php
+++ b/concat-css.php
@@ -40,11 +40,11 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 		$stylesheets = array();
 		$siteurl = apply_filters( 'page_optimize_site_url', $this->base_url );
 
-        // get the website base url
-        $url_raw = parse_url($siteurl);
-        $baseurl = $url_raw['scheme']."://".$url_raw['host'];
+		// get the website base url
+		$url_raw = parse_url( $siteurl );
+		$baseurl = $url_raw['scheme'] . "://" . $url_raw['host'];
 
-        $this->all_deps( $handles );
+		$this->all_deps( $handles );
 
 		$stylesheet_group_index = 0;
 		// Merge CSS into a single file

--- a/concat-css.php
+++ b/concat-css.php
@@ -64,10 +64,10 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 			$css_url_parsed = parse_url( $obj->src );
 			$extra = $obj->extra;
 
-			// Only try to concat static css files
-			if ( false !== strpos( $css_url_parsed['path'], '.css' ) ) {
-				$do_concat = true;
-			} else {
+			// try to concat static css files
+			$do_concat = true;
+
+			if ( 0 == strpos( $css_url_parsed['path'], '.css' ) ) {
 
 				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 					echo sprintf( "\n<!-- No Concat CSS %s => Maybe Not Static File %s -->\n", esc_html( $handle ), esc_html( $obj->src ) );

--- a/concat-js.php
+++ b/concat-js.php
@@ -59,6 +59,11 @@ class Page_Optimize_JS_Concat extends WP_Scripts {
 		$handles = false === $handles ? $this->queue : (array) $handles;
 		$javascripts = array();
 		$siteurl = apply_filters( 'page_optimize_site_url', $this->base_url );
+
+		// get the website base url
+		$url_raw = parse_url($siteurl);
+        $baseurl = $url_raw['scheme']."://".$url_raw['host'];
+
 		$this->all_deps( $handles );
 		$level = 0;
 
@@ -231,7 +236,7 @@ class Page_Optimize_JS_Concat extends WP_Scripts {
 
 					$href = $siteurl . "/_static/??" . $path_str;
 				} elseif ( isset( $js_array['paths'] ) && is_array( $js_array['paths'] ) ) {
-					$href = Page_Optimize_Utils::cache_bust_mtime( $js_array['paths'][0], $siteurl );
+					$href = Page_Optimize_Utils::cache_bust_mtime( $js_array['paths'][0], $baseurl );
 				}
 
 				$this->done = array_merge( $this->done, $js_array['handles'] );

--- a/concat-js.php
+++ b/concat-js.php
@@ -58,11 +58,7 @@ class Page_Optimize_JS_Concat extends WP_Scripts {
 	function do_items( $handles = false, $group = false ) {
 		$handles = false === $handles ? $this->queue : (array) $handles;
 		$javascripts = array();
-		$siteurl = apply_filters( 'page_optimize_site_url', $this->base_url );
-
-		// get the website base url
-		$url_raw = parse_url($siteurl);
-		$baseurl = $url_raw['scheme']."://".$url_raw['host'];
+		$siteurl = apply_filters( 'page_optimize_site_url', $this->dependency_path_mapping->base_url );
 
 		$this->all_deps( $handles );
 		$level = 0;
@@ -234,9 +230,9 @@ class Page_Optimize_JS_Concat extends WP_Scripts {
 						}
 					}
 
-					$href = $siteurl . "/_static/??" . $path_str;
+					$href = $siteurl . $this->dependency_path_mapping->site_subdir_path . "/_static/??" . $path_str;
 				} elseif ( isset( $js_array['paths'] ) && is_array( $js_array['paths'] ) ) {
-					$href = Page_Optimize_Utils::cache_bust_mtime( $js_array['paths'][0], $baseurl );
+					$href = Page_Optimize_Utils::cache_bust_mtime( $js_array['paths'][0], $siteurl );
 				}
 
 				$this->done = array_merge( $this->done, $js_array['handles'] );

--- a/concat-js.php
+++ b/concat-js.php
@@ -62,7 +62,7 @@ class Page_Optimize_JS_Concat extends WP_Scripts {
 
 		// get the website base url
 		$url_raw = parse_url($siteurl);
-        $baseurl = $url_raw['scheme']."://".$url_raw['host'];
+		$baseurl = $url_raw['scheme']."://".$url_raw['host'];
 
 		$this->all_deps( $handles );
 		$level = 0;

--- a/dependency-path-mapping.php
+++ b/dependency-path-mapping.php
@@ -96,7 +96,9 @@ class Page_Optimize_Dependency_Path_Mapping {
 			$file_path = $this->content_dir . substr( $uri_path, strlen( $this->content_uri_path ) );
         } else if ( static::is_descendant_uri(  '/wp-includes/', $uri_path ) ) {
             $file_path = $this->site_dir . $uri_path;
-		} else if ( static::is_descendant_uri( $this->site_uri_path, $uri_path ) ) {
+        } else if ( static::is_descendant_uri(  '/wp-admin/', $uri_path ) ) {
+            $file_path = $this->site_dir . $uri_path;
+        } else if ( static::is_descendant_uri( $this->site_uri_path, $uri_path ) ) {
 			$file_path = $this->site_dir . substr( $uri_path, strlen( $this->site_uri_path ) );
 		}
 

--- a/dependency-path-mapping.php
+++ b/dependency-path-mapping.php
@@ -10,10 +10,10 @@ class Page_Optimize_Dependency_Path_Mapping {
 	public $site_url;
 
 	// Save URI path and dir for mapping URIs to filesystem paths
-    public $base_url = null;
-    public $site_subdir_path = null;
-    public $site_uri_path = null;
-    public $site_dir = null;
+	public $base_url = null;
+	public $site_subdir_path = null;
+	public $site_uri_path = null;
+	public $site_dir = null;
 	public $content_uri_path = null;
 	public $content_dir = null;
 	public $plugin_uri_path = null;
@@ -31,15 +31,15 @@ class Page_Optimize_Dependency_Path_Mapping {
 		if ( null === $site_url ) {
 			$site_url = is_multisite() ? get_site_url( get_current_blog_id() ) : get_site_url();
 		}
-        // parse the site url for further use
+		// parse the site url for further use
 		$url_parsed = parse_url($site_url);
 
-        $this->base_url = $url_parsed['scheme'].'://'.$url_parsed['host'];
-        $this->site_subdir_path = str_replace( $this->base_url, "", $site_url );
+		$this->base_url = $url_parsed['scheme'].'://'.$url_parsed['host'];
+		$this->site_subdir_path = str_replace( $this->base_url, "", $site_url );
 
 		$site_url = trailingslashit( $site_url );
 		$this->site_url = $site_url;
-        $this->site_uri_path = $url_parsed['path'];
+		$this->site_uri_path = $url_parsed['path'];
 		$this->site_dir = trailingslashit( $site_dir );
 
 		// Only resolve content URLs if they are under the site URL
@@ -107,8 +107,8 @@ class Page_Optimize_Dependency_Path_Mapping {
 			$file_path = $this->plugin_dir . substr( $uri_path, strlen( $this->plugin_uri_path ) );
 		} else if ( isset( $this->content_uri_path ) && static::is_descendant_uri( $this->content_uri_path, $uri_path ) ) {
 			$file_path = $this->content_dir . substr( $uri_path, strlen( $this->content_uri_path ) );
-        } else if ( static::is_descendant_uri( $this->site_uri_path, $uri_path ) ) {
-            $file_path = $this->site_dir . substr( $uri_path, strlen( $this->site_uri_path ) );
+		} else if ( static::is_descendant_uri( $this->site_uri_path, $uri_path ) ) {
+			$file_path = $this->site_dir . substr( $uri_path, strlen( $this->site_uri_path ) );
 		}
 
 		if ( isset( $file_path ) && file_exists( $file_path ) ) {

--- a/dependency-path-mapping.php
+++ b/dependency-path-mapping.php
@@ -10,8 +10,10 @@ class Page_Optimize_Dependency_Path_Mapping {
 	public $site_url;
 
 	// Save URI path and dir for mapping URIs to filesystem paths
-	public $site_uri_path = null;
-	public $site_dir = null;
+    public $base_url = null;
+    public $site_subdir_path = null;
+    public $site_uri_path = null;
+    public $site_dir = null;
 	public $content_uri_path = null;
 	public $content_dir = null;
 	public $plugin_uri_path = null;
@@ -29,9 +31,15 @@ class Page_Optimize_Dependency_Path_Mapping {
 		if ( null === $site_url ) {
 			$site_url = is_multisite() ? get_site_url( get_current_blog_id() ) : get_site_url();
 		}
+        // parse the site url for further use
+		$url_parsed = parse_url($site_url);
+
+        $this->base_url = $url_parsed['scheme'].'://'.$url_parsed['host'];
+        $this->site_subdir_path = str_replace( $this->base_url, "", $site_url );
+
 		$site_url = trailingslashit( $site_url );
 		$this->site_url = $site_url;
-		$this->site_uri_path = parse_url( $site_url, PHP_URL_PATH );
+        $this->site_uri_path = $url_parsed['path'];
 		$this->site_dir = trailingslashit( $site_dir );
 
 		// Only resolve content URLs if they are under the site URL
@@ -87,6 +95,11 @@ class Page_Optimize_Dependency_Path_Mapping {
 			return false;
 		}
 
+		// Adds the sub-directory path if not present, like all other resources have if the website is hosted into a sub-folder
+		if (!empty($this->site_subdir_path) && !page_optimize_starts_with($this->site_subdir_path, $uri_path)) {
+            $uri_path = $this->site_subdir_path . $uri_path;
+        }
+
 		// The plugin URI path may be contained within the content URI path, so we check it before the content URI.
 		// And both the plugin and content URI paths must be contained within the site URI path,
 		// so we check them before checking the site URI.
@@ -94,12 +107,8 @@ class Page_Optimize_Dependency_Path_Mapping {
 			$file_path = $this->plugin_dir . substr( $uri_path, strlen( $this->plugin_uri_path ) );
 		} else if ( isset( $this->content_uri_path ) && static::is_descendant_uri( $this->content_uri_path, $uri_path ) ) {
 			$file_path = $this->content_dir . substr( $uri_path, strlen( $this->content_uri_path ) );
-        } else if ( static::is_descendant_uri(  '/wp-includes/', $uri_path ) ) {
-            $file_path = $this->site_dir . $uri_path;
-        } else if ( static::is_descendant_uri(  '/wp-admin/', $uri_path ) ) {
-            $file_path = $this->site_dir . $uri_path;
         } else if ( static::is_descendant_uri( $this->site_uri_path, $uri_path ) ) {
-			$file_path = $this->site_dir . substr( $uri_path, strlen( $this->site_uri_path ) );
+            $file_path = $this->site_dir . substr( $uri_path, strlen( $this->site_uri_path ) );
 		}
 
 		if ( isset( $file_path ) && file_exists( $file_path ) ) {

--- a/dependency-path-mapping.php
+++ b/dependency-path-mapping.php
@@ -94,6 +94,8 @@ class Page_Optimize_Dependency_Path_Mapping {
 			$file_path = $this->plugin_dir . substr( $uri_path, strlen( $this->plugin_uri_path ) );
 		} else if ( isset( $this->content_uri_path ) && static::is_descendant_uri( $this->content_uri_path, $uri_path ) ) {
 			$file_path = $this->content_dir . substr( $uri_path, strlen( $this->content_uri_path ) );
+        } else if ( static::is_descendant_uri(  '/wp-includes/', $uri_path ) ) {
+            $file_path = $this->site_dir . $uri_path;
 		} else if ( static::is_descendant_uri( $this->site_uri_path, $uri_path ) ) {
 			$file_path = $this->site_dir . substr( $uri_path, strlen( $this->site_uri_path ) );
 		}

--- a/dependency-path-mapping.php
+++ b/dependency-path-mapping.php
@@ -96,9 +96,9 @@ class Page_Optimize_Dependency_Path_Mapping {
 		}
 
 		// Adds the sub-directory path if not present, like all other resources have if the website is hosted into a sub-folder
-		if (!empty($this->site_subdir_path) && !page_optimize_starts_with($this->site_subdir_path, $uri_path)) {
-            $uri_path = $this->site_subdir_path . $uri_path;
-        }
+		if ( ! empty( $this->site_subdir_path ) && ! page_optimize_starts_with( $this->site_subdir_path, $uri_path ) ) {
+			$uri_path = $this->site_subdir_path . $uri_path;
+		}
 
 		// The plugin URI path may be contained within the content URI path, so we check it before the content URI.
 		// And both the plugin and content URI paths must be contained within the site URI path,

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -26,7 +26,7 @@ define( 'PAGE_OPTIMIZE_CRON_CACHE_CLEANUP_JOB', 'page_optimize_cron_cache_cleanu
 // TODO: Copy tests from nginx-http-concat and/or write them
 
 // TODO: Make concat URL dir configurable
-if ( isset( $_SERVER['REQUEST_URI'] ) && '/_static/' === substr( $_SERVER['REQUEST_URI'], 0, 9 ) ) {
+if ( $_SERVER['REQUEST_URI'] != false && stripos( $_SERVER['REQUEST_URI'], '/_static/' ) !== false ) {
 	require_once __DIR__ . '/service.php';
 	exit;
 }

--- a/service.php
+++ b/service.php
@@ -187,6 +187,11 @@ function page_optimize_build_output() {
 			page_optimize_status_exit( 500 );
 		}
 
+		// Removes source mapping URLs as they are unnecessary after concatenation
+		if ( false !== strpos( $buf, 'sourceMappingURL' ) ) {
+			$buf = preg_replace('/(\/\*# sourceMappingURL=.+\.map \*\/)/', "" , $buf );
+		}
+
 		if ( 'text/css' == $mime_type ) {
 			$dirpath = '/' . ltrim( dirname( $uri ), '/' );
 
@@ -199,11 +204,6 @@ function page_optimize_build_output() {
 				'$1' . ( $dirpath == '/' ? '/' : $dirpath . '/' ) . '$2)',
 				$buf
 			);
-
-			// Removes source mapping URLs as they are unnecessary after concatenation
-			if ( false !== strpos( $buf, 'sourceMappingURL' ) ) {
-				$buf = preg_replace('/(\/\*# sourceMappingURL=.+\.map \*\/)/', "" , $buf );
-			}
 
 			// The @charset rules must be on top of the output
 			if ( 0 === strpos( $buf, '@charset' ) ) {

--- a/service.php
+++ b/service.php
@@ -200,6 +200,11 @@ function page_optimize_build_output() {
 				$buf
 			);
 
+			// Removes source mapping URLs as they are unnecessary after concatenation
+			if ( false !== strpos( $buf, 'sourceMappingURL' ) ) {
+				$buf = preg_replace('/(\/\*# sourceMappingURL=.+\.map \*\/)/', "" , $buf );
+			}
+
 			// The @charset rules must be on top of the output
 			if ( 0 === strpos( $buf, '@charset' ) ) {
 				preg_replace_callback(

--- a/service.php
+++ b/service.php
@@ -189,7 +189,7 @@ function page_optimize_build_output() {
 
 		// Removes source mapping URLs as they are unnecessary after concatenation
 		if ( false !== strpos( $buf, 'sourceMappingURL' ) ) {
-			$buf = preg_replace('/(\/\*# sourceMappingURL=.+\.map \*\/)/', "" , $buf );
+			$buf = preg_replace('/\/\*# sourceMappingURL=.+\.map \*\//', "" , $buf );
 		}
 
 		if ( 'text/css' == $mime_type ) {

--- a/service.php
+++ b/service.php
@@ -188,7 +188,7 @@ function page_optimize_build_output() {
 		}
 
 		if ( 'text/css' == $mime_type ) {
-			$dirpath = '/' . ltrim( $subdir_path_prefix . dirname( $uri ), '/' );
+			$dirpath = '/' . ltrim( dirname( $uri ), '/' );
 
 			// url(relative/path/to/file) -> url(/absolute/and/not/relative/path/to/file)
 			$buf = page_optimize_relative_path_replace( $buf, $dirpath );

--- a/service.php
+++ b/service.php
@@ -189,7 +189,7 @@ function page_optimize_build_output() {
 
 		// Removes source mapping URLs as they are unnecessary after concatenation
 		if ( false !== strpos( $buf, 'sourceMappingURL' ) ) {
-			$buf = preg_replace('/\/\*# sourceMappingURL=.+\.map \*\//', "" , $buf );
+			$buf = preg_replace('/\/[\/*].*sourceMapping.+/', "" , $buf );
 		}
 
 		if ( 'text/css' == $mime_type ) {


### PR DESCRIPTION
Since the PR #47 was old and the code need to be updated, I have created a new PR to fix this problem that need less fixes, probably because in time this issue has been almost solved except for few things. 

in addition, I've noticed that there were a bunch of issues open since a long time, it's a pity because this plugin is well written and goes pretty fast.

In particular I (hope to) have closed:
- The path if the website was hosted in a subdirectory (you need to strip the subdirectory name from path because the base url already contains it) #47 
- Css files order  #52 #58 #60 
- Removed sourcemap from minified files #53 

I tested the plugin in a "normal" site (hosted in the root folder) and it works after these changes.