### PR TITLE
Fix PHP 8.1 warning

### DIFF
--- a/service.php
+++ b/service.php
@@ -207,7 +207,7 @@ function page_optimize_build_output() {
 					function ( $match ) {
 						global $pre_output;
 
-						if ( 0 === strpos( $pre_output, '@charset' ) ) {
+						if ( 0 === strpos( (string) $pre_output, '@charset' ) ) {
 							return '';
 						}
 


### PR DESCRIPTION
```
strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /wordpress/plugins/page-optimize/0.5.2/service.php on line 210
```