### PR TITLE
Adding elementor-app to the CSS Exclude List

### DIFF
--- a/page-optimize.php
+++ b/page-optimize.php
@@ -168,8 +168,8 @@ function page_optimize_css_exclude_list() {
 }
 
 function page_optimize_css_exclude_list_default() {
-	// WordPress core stuff
-	return [ 'admin-bar', 'dashicons' ];
+	// WordPress Core and known conflicting plugins
+	return [ 'admin-bar', 'dashicons', 'elementor-app' ];
 }
 
 function page_optimize_sanitize_js_load_mode( $value ) {


### PR DESCRIPTION
Elementor styles don't work well with Page Optimize. Adding elementor-app to page_optimize_css_exclude_list_default will fix it.