### PR TITLE
Bail when in Editor & increase concatenation limit.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bin/dotorg-svn-deploy
 .DS_Store
 vendor
+.idea

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -272,9 +272,14 @@ function page_optimize_bail() {
 		return true;
 	}
 
-	// Bail if we're in the editor
+	// Bail if we're in any of the excluded pages.
 	global $pagenow;
-	if ( isset( $pagenow ) && ( $pagenow == 'post.php' || $pagenow == 'post-new.php' ) ) {
+	$excluded_pages = array(
+		'post.php',
+		'post-new.php',
+		'site-editor.php',
+	);
+	if ( isset( $pagenow ) && in_array( $pagenow, $excluded_pages ) ) {
 		return true;
 	}
 

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -4,7 +4,7 @@ Plugin Name: Page Optimize
 Plugin URI: https://wordpress.org/plugins/page-optimize/
 Description: Optimizes JS and CSS for faster page load and render in the browser.
 Author: Automattic
-Version: 0.5.3
+Version: 0.5.4
 Author URI: http://automattic.com/
 */
 
@@ -269,6 +269,12 @@ function page_optimize_bail() {
 	// Bail if we're in customizer
 	global $wp_customize;
 	if ( isset( $wp_customize ) ) {
+		return true;
+	}
+
+	// Bail if we're in the editor
+	global $pagenow;
+	if ( isset( $pagenow ) && ( $pagenow == 'post.php' || $pagenow == 'post-new.php' ) ) {
 		return true;
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -49,6 +49,9 @@ Supported query params:
 
 == Changelog ==
 
+= 0.5.4 =
+* Bail when editing pages or posts in the Editor. Increased the max concatenated file limit.
+
 = 0.5.1 =
 * Bail when editing pages in Brizy Editor (it errors when JavaScript load mode is `async`).
 

--- a/service.php
+++ b/service.php
@@ -84,7 +84,7 @@ function page_optimize_build_output() {
 	require_once __DIR__ . '/cssmin/cssmin.php';
 
 	/* Config */
-	$concat_max_files = 150;
+	$concat_max_files = 300;
 	$concat_unique = true;
 
 	/* Main() */


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/80713

# Description
We're experiencing some issues caused by the page optimizer being loaded on the Editor. You can see the exact error described in the referenced issue or in this conversation p1692205609474649-slack-C02FMH4G8.

After some investigation, I've noticed that we have a hard limit on the number of files that we can concatenate, which is not that hard to hit. With just a dozen Editor plugins we're already reaching the limit.

# Solution
I've increased the limit, now it's 2x the original so that we avoid hitting it as easily. On the other hand, we now bail out and do not load the plugin if we are in the Editor.

# Testing Instructions
- On an Atomic site...
- Add plugins until you can reproduce the error.
- Upload the plugin to your WoA site.
- Open the Editor and with Chrome's developer tools...
- Look at the network tab and filter by `static` you shouldn't see any requests and the Editor should load without errors.
- [Optional] Comment the lines in the plugin that bail and open the Editor, you also should see that the Editor loads correctly and that there is a request when filtering by `static` in Chrome's Network tab.