### PR TITLE
Always load settings

### DIFF
--- a/page-optimize.php
+++ b/page-optimize.php
@@ -297,13 +297,15 @@ function page_optimize_bail() {
 }
 
 function page_optimize_init() {
+	// The settings page should always be available without regard to possible bail states.
+	require_once __DIR__ . '/settings.php';
+
 	if ( page_optimize_bail() ) {
 		return;
 	}
 
 	page_optimize_schedule_cache_cleanup();
 
-	require_once __DIR__ . '/settings.php';
 	require_once __DIR__ . '/concat-css.php';
 	require_once __DIR__ . '/concat-js.php';
 


### PR DESCRIPTION
Working on a site where the Settings page does not load via the link from Calypso and realized this is a potential oddity.

Even if we're using a theme or on a page where we do not want the optimization to run, we should still provide the settings menu item.

Additionally, we could, though, scope it to the admin to avoid loading the settings page code on front-end requests.
