### PR TITLE
Handle inline scripts even when `src` is false

### DIFF
--- a/concat-js.php
+++ b/concat-js.php
@@ -76,9 +76,17 @@ class Page_Optimize_JS_Concat extends WP_Scripts {
 			}
 
 			if ( ! $this->registered[ $handle ]->src ) { // Defines a group.
-				// if there are localized items, echo them
-				$this->print_extra_script( $handle );
-				$this->done[] = $handle;
+				if ( $this->has_inline_content( $handle ) ) {
+					$level ++;
+					$javascripts[ $level ]['type'] = 'do_item';
+					$javascripts[ $level ]['handle'] = $handle;
+					$level ++;
+					unset( $this->to_do[ $key ] );
+				} else {
+					// if there are localized items, echo them
+					$this->print_extra_script( $handle );
+					$this->done[] = $handle;
+				}
 				continue;
 			}
 


### PR DESCRIPTION
When a handle is registered with no `src`, any inline scripts associated with the handle were being skipped.

Instead, we need to handle them in the same way that scripts with a `src` are handled.

## Testing

* On an Atomic dev site, use the Jetpack Beta Tester plugin to install 13.1-a.1 and create a post using a slideshow block. Observe that it's broken as described in p1705445569607789-slack-CBG1CP4EN
* Apply this change and force-reload the post. The slideshow block should now function.