### PR TITLE
Add non-configurable exclusion list for known incompatible scripts

### DIFF
--- a/page-optimize.php
+++ b/page-optimize.php
@@ -136,17 +136,25 @@ function page_optimize_js_load_mode_default() {
 	return '';
 }
 
+function page_optimize_js_known_incompatible() {
+	// Scripts that are known to break when concatenated
+	return [
+		'monsterinsights-vue-frontend', // Requires type="module"
+	];
+}
+
 function page_optimize_js_exclude_list() {
-	$exclude_list = get_option( 'page_optimize-js-exclude' );
+	$incompat_list = page_optimize_js_known_incompatible();
+	$exclude_list  = get_option( 'page_optimize-js-exclude' );
 	if ( false === $exclude_list ) {
 		// Use the default since the option is not set
-		return page_optimize_js_exclude_list_default();
+		return array_merge( page_optimize_js_exclude_list_default(), $incompat_list );
 	}
 	if ( '' === $exclude_list ) {
-		return [];
+		return $incompat_list;
 	}
 
-	return explode( ',', $exclude_list );
+	return array_merge( $incompat_list, explode( ',', $exclude_list ) );
 }
 
 function page_optimize_js_exclude_list_default() {


### PR DESCRIPTION
**Summary**
Creates a hardcoded list of scripts known to break concatenation, starting with MonsterInsights which requires `type="module"`. Unlike the configurable exclusion list, this applies to all installations regardless of user settings.

**Background**
MonsterInsights modifies its script tag to `type="module"` via `script_loader_tag` filter, which breaks when concatenated because the concatenated version loses this attribute, and uses ES6 import statements that require it. Found here: 9017084-zd-a8c

**Possible Approach 1:** Add to default exclusion list
```
  + Simple, uses existing mechanism
  - Only works for new installations or default settings. Anyone who has tweaked doesn't get the fix.
```
  
**Possible Approach 2:** Detect module scripts by running `script_loader_tag` filter and checking results.
```
  + Catches all module scripts using this technique automatically
  - Some runtime overhead checking script tags
  - Not sure how popular this pattern actually is.
```
 
**Current Approach 3:** Known incompatible list
```
  + Works for all installations regardless of settings
  + Very little runtime overhead
  + Clear separation between user and compatibility exclusions
  - Requires code changes for new conflicts
```

**Steps to Reproduce**
* On a site, install and activate both page-optimize and [MonsterInsights](https://wordpress.org/plugins/google-analytics-for-wordpress/).
* Visit homepage.
* Check browser console for: `Uncaught SyntaxError: import declarations may only appear at top level of module`.

**To verify fix**
* Reproduce the problem
* apply the patch
* visit the homepage
* the SyntaxError seen above should no longer appear.