### PR TITLE
Update tested to from 6.8 to 6.9

### DIFF
--- a/page-optimize.php
+++ b/page-optimize.php
@@ -4,7 +4,7 @@ Plugin Name: Page Optimize
 Plugin URI: https://wordpress.org/plugins/page-optimize/
 Description: Optimizes JS and CSS for faster page load and render in the browser.
 Author: Automattic
-Version: 0.5.7
+Version: 0.5.8
 Author URI: http://automattic.com/
 */
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: aidvu, bjorsch, bpayton, rcrdortiz
 Tags: performance
 Requires at least: 5.3
-Tested up to: 6.8
+Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 0.5.7
+Stable tag: 0.5.8
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -48,6 +48,9 @@ Supported query params:
 * `load-mode-js` controls how non-critical JavaScript are loaded. Values: 'defer' for [deferred](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-defer), 'async' for [async loading](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-async), any other value indicates the feature should be disabled.
 
 == Changelog ==
+
+= 0.5.8 =
+* Update Tested Up To Version to 6.9.
 
 = 0.5.7 =
 * Update Tested Up To Version to 6.8.


### PR DESCRIPTION
WP 6.9 is scheduled for release today 12/2. We've tested page-optimize against the beta and RC releases without concern. 
Small update to change the "Tested up to:" version from 6.8 to 6.9.
Also confirmed that several plugins wordpress-seo and others have updated to 6.9.

Compare with https://github.com/Automattic/page-optimize/pull/87