### PR TITLE
Fix CSS concatenation to preserve original stylesheet order

### DIFF
--- a/concat-css.php
+++ b/concat-css.php
@@ -155,7 +155,7 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 				if ( $this->do_item( $css_array['handle'], $group ) ) {
 					$this->done[] = $css_array['handle'];
 				}
-			} elseif ( 'concat' === $css_array['type'] ) {
+			} elseif ( 'concat' === $css_array['type'] && isset( $css_array['paths'] ) ) {
 				// Process each media type within the concat group
 				foreach ( $css_array['paths'] as $media => $css ) {
 					if ( count( $css ) > 1 ) {


### PR DESCRIPTION
## Summary

- Fixes CSS concatenation reordering that caused theme stylesheets to appear before Gutenberg's global styles
- Adopts the same level-based grouping approach used in `concat-js.php`
- Non-concatenatable items now break concat groups, preserving original WordPress enqueue order

## Problem

The previous implementation grouped all concatenatable CSS files into a single bundle output first, before non-concatenatable items. This broke the relative order between concatenated stylesheets and inline styles.

This caused Gutenberg's `a:where(:not(.wp-element-button)) { text-decoration: underline }` rule to override theme link styling (e.g., `a { text-decoration: none }`) due to CSS cascade order—when selectors have equal specificity, the last one wins.

## Solution

Use a `$level` counter where non-concatenatable items break the current concat group (double-increment pattern from `concat-js.php`), preserving the original stylesheet order.

Fixes https://linear.app/a8c/issue/DOTTHEM-159 and https://github.com/Automattic/page-optimize/issues/84

## Test plan

- [ ] Verify on a classic theme (Sela, Dyad 2, Newspaper) that post title links are not underlined (you may need GB 22.4.0, or GB 22.4.1. GB 22.4.2 has a [change](https://github.com/WordPress/gutenberg/pull/74901) obsoleting this test)
- [ ] Verify CSS concatenation still works (check for `_static/??` URLs in page source)
- [ ] Verify stylesheets with inline styles maintain correct cascade order