### PR TITLE
Add more tests, including known ordering bug tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,16 +23,21 @@ jobs:
           docker compose run --rm tests bash -lc "bin/run-tests-docker.sh --exclude-group css-order-bug"
       - name: Run known-bug tests (informational)
         id: known-bugs
-        continue-on-error: true
         run: |
+          set +e
           docker compose run --rm tests bash -lc "bin/run-tests-docker.sh --group css-order-bug"
+          status=$?
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          exit 0
       - name: Report known-bug status
         if: always()
         run: |
-          if [ \"${{ steps.known-bugs.outcome }}\" == \"failure\" ]; then
-            echo \"::warning::Known CSS order bugs are still failing\"
+          if [ "${{ steps.known-bugs.outputs.status }}" != "0" ]; then
+            echo "::warning::Known CSS order bugs are still failing"
+            echo "⚠️ Known CSS order bugs are still failing." >> "$GITHUB_STEP_SUMMARY"
           else
-            echo \"::notice::Known CSS order bugs are now passing—consider removing the group annotation\"
+            echo "::notice::Known CSS order bugs are now passing—consider removing the group annotation"
+            echo "✅ Known CSS order bugs are now passing — consider removing the group annotation." >> "$GITHUB_STEP_SUMMARY"
           fi
       - name: Cleanup
         if: always()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,9 +14,26 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Run PHPUnit (Docker)
+      - name: Build test image
+        run: docker compose build tests
+      - name: Start DB
+        run: docker compose up -d db
+      - name: Run PHPUnit (excluding known bugs)
         run: |
-          docker compose up --build --abort-on-container-exit --exit-code-from tests
+          docker compose run --rm tests bash -lc "bin/run-tests-docker.sh --exclude-group css-order-bug"
+      - name: Run known-bug tests (informational)
+        id: known-bugs
+        continue-on-error: true
+        run: |
+          docker compose run --rm tests bash -lc "bin/run-tests-docker.sh --group css-order-bug"
+      - name: Report known-bug status
+        if: always()
+        run: |
+          if [ \"${{ steps.known-bugs.outcome }}\" == \"failure\" ]; then
+            echo \"::warning::Known CSS order bugs are still failing\"
+          else
+            echo \"::notice::Known CSS order bugs are now passing—consider removing the group annotation\"
+          fi
       - name: Cleanup
         if: always()
         run: docker compose down -v

--- a/bin/run-tests-docker.sh
+++ b/bin/run-tests-docker.sh
@@ -74,4 +74,8 @@ export WP_TESTS_PHPUNIT_POLYFILLS_PATH="${polyfills_path}"
 
 bin/install-wp-tests.sh "$DB_NAME" "$DB_USER" "$DB_PASS" "$DB_HOST" "$WP_VERSION" "$SKIP_DB_CREATE"
 
-phpunit
+if [ "$#" -gt 0 ]; then
+  phpunit "$@"
+else
+  phpunit
+fi

--- a/tests/class-css-concat-test-case.php
+++ b/tests/class-css-concat-test-case.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Base test case for CSS concatenation tests.
+ *
+ * Provides shared setup, teardown, and helper methods for testing the
+ * Page_Optimize_CSS_Concat class. Subclasses only need to define test methods.
+ */
+abstract class CSS_Concat_Test_Case extends WP_UnitTestCase {
+	/** @var string[] Temporary CSS files created during tests, cleaned up in tear_down(). */
+	protected $tmp_files = [];
+
+	public function set_up(): void {
+		parent::set_up();
+		require_once dirname( __DIR__ ) . '/concat-css.php';
+
+		// Hook into both the plugin's and WordPress core's style_loader_tag filters
+		// so we can inject data-handles attributes for test assertions.
+		add_filter( 'page_optimize_style_loader_tag', [ $this, 'inject_data_handles_into_page_optimize_tag' ], 10, 4 );
+		add_filter( 'style_loader_tag', [ $this, 'inject_data_handles_into_core_tag' ], 10, 4 );
+	}
+
+	public function tear_down(): void {
+		remove_filter( 'page_optimize_style_loader_tag', [ $this, 'inject_data_handles_into_page_optimize_tag' ], 10 );
+		remove_filter( 'style_loader_tag', [ $this, 'inject_data_handles_into_core_tag' ], 10 );
+
+		// Clean up any temporary CSS files created during the test.
+		foreach ( $this->tmp_files as $file ) {
+			@unlink( $file );
+		}
+		$this->tmp_files = [];
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Filter callback for concatenated <link> tags.
+	 *
+	 * Injects a data-handles attribute containing a comma-separated list of
+	 * all handles included in the concatenated tag (e.g., data-handles="a,b,c").
+	 */
+	public function inject_data_handles_into_page_optimize_tag( $tag, $handles, $href, $media ) {
+		$list = is_array( $handles ) ? implode( ',', $handles ) : (string) $handles;
+
+		if ( false === strpos( $tag, 'data-handles=' ) ) {
+			$tag = preg_replace(
+				'/<link\s/i',
+				'<link data-handles="' . esc_attr( $list ) . '" ',
+				$tag,
+				1
+			);
+		}
+		return $tag;
+	}
+
+	/**
+	 * Filter callback for non-concatenated <link> tags (WordPress core).
+	 *
+	 * Injects a data-handles attribute containing the single handle
+	 * (e.g., data-handles="a").
+	 */
+	public function inject_data_handles_into_core_tag( $tag, $handle, $href, $media ) {
+		if ( false === strpos( $tag, 'data-handles=' ) ) {
+			$tag = preg_replace(
+				'/<link\s/i',
+				'<link data-handles="' . esc_attr( $handle ) . '" ',
+				$tag,
+				1
+			);
+		}
+		return $tag;
+	}
+
+	/**
+	 * Creates a temporary CSS file in wp-content and returns its URL.
+	 *
+	 * Files are automatically cleaned up in tear_down().
+	 */
+	protected function make_content_css( string $filename, string $contents = '/* test */' ): string {
+		$fs     = trailingslashit( WP_CONTENT_DIR ) . $filename;
+		$result = file_put_contents( $fs, $contents );
+		$this->assertNotFalse( $result, 'Failed to write temporary CSS fixture.' );
+		$this->tmp_files[] = $fs;
+
+		return content_url( $filename );
+	}
+
+	/**
+	 * Creates a fresh Page_Optimize_CSS_Concat instance for testing.
+	 */
+	protected function new_concat_styles(): Page_Optimize_CSS_Concat {
+		$core           = new WP_Styles();
+		$core->base_url = untrailingslashit( site_url() );
+
+		$concat = new Page_Optimize_CSS_Concat( $core );
+		// Disable compression so URLs remain human-readable in test output.
+		$concat->allow_gzip_compression = false;
+
+		return $concat;
+	}
+
+	/**
+	 * Renders all enqueued styles and returns the generated HTML.
+	 */
+	protected function render( WP_Styles $styles ): string {
+		ob_start();
+		$styles->do_items();
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * Parses rendered HTML and returns an array of handle groups in document order.
+	 *
+	 * Each group represents one <link> tag. A concatenated tag will have multiple
+	 * handles (e.g., ['a', 'b']), while a regular tag will have one (e.g., ['a']).
+	 */
+	protected function extract_handle_groups( string $html ): array {
+		preg_match_all( '/data-handles=["\']([^"\']+)["\']/', $html, $m );
+		$groups = [];
+		foreach ( $m[1] as $list ) {
+			$handles = array_values( array_filter( array_map( 'trim', explode( ',', $list ) ) ) );
+			$groups[] = $handles;
+		}
+		return $groups;
+	}
+
+	/**
+	 * Flattens an array of handle groups into a single ordered list of handles.
+	 *
+	 * Useful for asserting overall handle order regardless of how they're grouped.
+	 */
+	protected function flatten_groups( array $groups ): array {
+		$out = [];
+		foreach ( $groups as $g ) {
+			foreach ( $g as $h ) {
+				$out[] = $h;
+			}
+		}
+		return $out;
+	}
+}

--- a/tests/test_css_concat_eligibility.php
+++ b/tests/test_css_concat_eligibility.php
@@ -1,0 +1,200 @@
+<?php
+
+require_once __DIR__ . '/class-css-concat-test-case.php';
+
+class Test_CSS_Concat_Eligibility extends CSS_Concat_Test_Case {
+	/**
+	* Verifies the basic success case: two local stylesheets with the same media type
+	* should be combined into a single <link> tag.
+	*
+	* Enqueue: a (local, media="all") -> b (local, media="all")
+	* Expected: [['a', 'b']]  (one <link> tag containing both)
+	*
+	* Also verifies the concatenated URL uses the /_static/?? combo endpoint
+	* (the server-side mechanism that serves multiple files in one request).
+	*/
+	public function test_concats_two_internal_styles_same_media_into_one_link_group(): void {
+		$styles = $this->new_concat_styles();
+
+		$a = $this->make_content_css( 'po-two-a.css' );
+		$b = $this->make_content_css( 'po-two-b.css' );
+
+		$styles->add( 'a', $a, [], null, 'all' );
+		$styles->add( 'b', $b, [], null, 'all' );
+
+		$styles->enqueue( 'a' );
+		$styles->enqueue( 'b' );
+
+		$html   = $this->render( $styles );
+		$groups = $this->extract_handle_groups( $html );
+
+		$this->assertSame( [ [ 'a', 'b' ] ], $groups );
+		$this->assertStringContainsString( '/_static/??', $html );
+	}
+
+	/**
+	* When there's only one stylesheet, don't use the combo endpoint - just serve it
+	* directly with a cache-busting timestamp (?m=...).
+	*
+	* The combo endpoint has overhead, so for a single file it's more efficient
+	* to serve it directly.
+	*/
+	public function test_single_internal_style_is_not_served_via_static_combo_endpoint(): void {
+		$styles = $this->new_concat_styles();
+
+		$a = $this->make_content_css( 'po-single-a.css' );
+		$styles->add( 'a', $a, [], null, 'all' );
+		$styles->enqueue( 'a' );
+
+		$html = $this->render( $styles );
+
+		$this->assertStringNotContainsString( '/_static/??', $html );
+		$this->assertStringContainsString( '?m=', $html );
+	}
+
+	/**
+	* Stylesheets wrapped in IE conditional comments (e.g., <!--[if lt IE 9]>)
+	* cannot be concatenated.
+	*
+	* Conditional comments are HTML-level constructs that wrap the entire <link> tag.
+	* You can't concatenate a conditional stylesheet with a non-conditional one - the
+	* conditional wrapper would incorrectly apply to both.
+	*/
+	public function test_conditional_styles_are_not_concatenated(): void {
+		$styles = $this->new_concat_styles();
+
+		$a = $this->make_content_css( 'po-cond-a.css' );
+		$b = $this->make_content_css( 'po-cond-b.css' );
+
+		$styles->add( 'a', $a, [], null, 'all' );
+		$styles->add( 'b', $b, [], null, 'all' );
+
+		// Mark b as conditional (IE, etc.) - should not be concatenated.
+		$styles->registered['b']->extra['conditional'] = 'lt IE 9';
+
+		$styles->enqueue( 'a' );
+		$styles->enqueue( 'b' );
+
+		$html   = $this->render( $styles );
+		$groups = $this->extract_handle_groups( $html );
+
+		foreach ( $groups as $g ) {
+			if ( in_array( 'b', $g, true ) ) {
+				$this->assertCount( 1, $g, 'Conditional stylesheet should never be concatenated with others.' );
+			}
+		}
+	}
+
+	/**
+	* When the page is in RTL (right-to-left) mode and a stylesheet has RTL-specific
+	* handling, it cannot be concatenated.
+	*
+	* WordPress can automatically swap in RTL versions of stylesheets (e.g.,
+	* style.css -> style-rtl.css). This substitution happens at render time,
+	* so these sheets need to stay separate.
+	*/
+	public function test_rtl_marked_styles_not_concatenated_when_text_direction_is_rtl(): void {
+		$styles = $this->new_concat_styles();
+
+		$a = $this->make_content_css( 'po-rtl-a.css' );
+		$b = $this->make_content_css( 'po-rtl-b.css' );
+
+		$styles->add( 'a', $a, [], null, 'all' );
+		$styles->add( 'b', $b, [], null, 'all' );
+
+		$styles->text_direction = 'rtl';
+		$styles->registered['b']->extra['rtl'] = true;
+
+		$styles->enqueue( 'a' );
+		$styles->enqueue( 'b' );
+
+		$html   = $this->render( $styles );
+		$groups = $this->extract_handle_groups( $html );
+
+		foreach ( $groups as $g ) {
+			if ( in_array( 'b', $g, true ) ) {
+				$this->assertCount( 1, $g, 'RTL stylesheet should not be concatenated when text_direction is rtl.' );
+			}
+		}
+	}
+
+	/**
+	* Admins can configure specific handles to be excluded from concatenation via the
+	* page_optimize-css-exclude option.
+	*
+	* Some stylesheets break when concatenated (e.g., they use @import or have
+	* relative URLs that break). This gives admins an escape hatch.
+	*/
+	public function test_exclusion_list_prevents_concatenation_of_handle(): void {
+		$old = get_option( 'page_optimize-css-exclude', null );
+		update_option( 'page_optimize-css-exclude', 'a' );
+
+		try {
+			$styles = $this->new_concat_styles();
+
+			$a = $this->make_content_css( 'po-ex-a.css' );
+			$b = $this->make_content_css( 'po-ex-b.css' );
+
+			$styles->add( 'a', $a, [], null, 'all' );
+			$styles->add( 'b', $b, [], null, 'all' );
+
+			$styles->enqueue( 'a' );
+			$styles->enqueue( 'b' );
+
+			$html   = $this->render( $styles );
+			$groups = $this->extract_handle_groups( $html );
+
+			foreach ( $groups as $g ) {
+				if ( in_array( 'a', $g, true ) ) {
+					$this->assertCount( 1, $g, 'Excluded handle should not be concatenated with others.' );
+				}
+			}
+		} finally {
+			// Restore option so this test doesn't affect other tests.
+			if ( null === $old ) {
+				delete_option( 'page_optimize-css-exclude' );
+			} else {
+				update_option( 'page_optimize-css-exclude', $old );
+			}
+		}
+	}
+
+	/**
+	* Developers can programmatically exclude handles using the css_do_concat filter hook.
+	*
+	* This is the code-based equivalent of the exclusion list-plugins or themes can
+	* hook in and prevent concatenation of specific stylesheets based on custom logic.
+	*/
+	public function test_css_do_concat_filter_can_disable_concatenation(): void {
+		add_filter( 'css_do_concat', function( $do_concat, $handle ) {
+			if ( 'a' === $handle ) {
+				return false;
+			}
+			return $do_concat;
+		}, 10, 2 );
+
+		try {
+			$styles = $this->new_concat_styles();
+
+			$a = $this->make_content_css( 'po-filter-a.css' );
+			$b = $this->make_content_css( 'po-filter-b.css' );
+
+			$styles->add( 'a', $a, [], null, 'all' );
+			$styles->add( 'b', $b, [], null, 'all' );
+
+			$styles->enqueue( 'a' );
+			$styles->enqueue( 'b' );
+
+			$html   = $this->render( $styles );
+			$groups = $this->extract_handle_groups( $html );
+
+			foreach ( $groups as $g ) {
+				if ( in_array( 'a', $g, true ) ) {
+					$this->assertCount( 1, $g, 'css_do_concat filter should be able to prevent concatenation of a handle.' );
+				}
+			}
+		} finally {
+			remove_all_filters( 'css_do_concat' );
+		}
+	}
+}

--- a/tests/test_css_concat_order.php
+++ b/tests/test_css_concat_order.php
@@ -1,111 +1,11 @@
 <?php
-// tests/test_css_concat_order.php
+
+require_once __DIR__ . '/class-css-concat-test-case.php';
 
 /**
  * @group page-optimize
  */
-class Test_CSS_Concat_Order extends WP_UnitTestCase {
-	private $tmp_files = [];
-
-	public function set_up(): void {
-		parent::set_up();
-
-		require_once dirname( __DIR__ ) . '/concat-css.php';
-
-		add_filter( 'page_optimize_style_loader_tag', [ $this, 'inject_data_handles_into_page_optimize_tag' ], 10, 4 );
-		add_filter( 'style_loader_tag', [ $this, 'inject_data_handles_into_core_tag' ], 10, 4 );
-	}
-
-	public function tear_down(): void {
-		remove_filter( 'page_optimize_style_loader_tag', [ $this, 'inject_data_handles_into_page_optimize_tag' ], 10 );
-		remove_filter( 'style_loader_tag', [ $this, 'inject_data_handles_into_core_tag' ], 10 );
-
-		foreach ( $this->tmp_files as $file ) {
-			@unlink( $file );
-		}
-		$this->tmp_files = [];
-
-		parent::tear_down();
-	}
-
-	public function inject_data_handles_into_page_optimize_tag( $tag, $handles, $href, $media ) {
-		$list = is_array( $handles ) ? implode( ',', $handles ) : (string) $handles;
-
-		if ( false === strpos( $tag, 'data-handles=' ) ) {
-			$tag = preg_replace(
-				'/<link\s/i',
-				'<link data-handles="' . esc_attr( $list ) . '" ',
-				$tag,
-				1
-			);
-		}
-		return $tag;
-	}
-
-	public function inject_data_handles_into_core_tag( $tag, $handle, $href, $media ) {
-		if ( false === strpos( $tag, 'data-handles=' ) ) {
-			$tag = preg_replace(
-				'/<link\s/i',
-				'<link data-handles="' . esc_attr( $handle ) . '" ',
-				$tag,
-				1
-			);
-		}
-		return $tag;
-	}
-
-	private function make_content_css( string $filename, string $contents = '/* test */' ): string {
-		$fs = trailingslashit( WP_CONTENT_DIR ) . $filename;
-		$result = file_put_contents( $fs, $contents );
-		$this->assertNotFalse( $result, 'Failed to write temporary CSS fixture.' );
-		$this->tmp_files[] = $fs;
-
-		return content_url( $filename );
-	}
-
-	private function new_concat_styles(): Page_Optimize_CSS_Concat {
-		$core = new WP_Styles();
-		$core->base_url = untrailingslashit( site_url() );
-
-		$concat = new Page_Optimize_CSS_Concat( $core );
-		// Disable compression so URLs remain human-readable in test output.
-		$concat->allow_gzip_compression = false;
-
-		return $concat;
-	}
-
-	private function render( WP_Styles $styles ): string {
-		ob_start();
-		$styles->do_items();
-		return (string) ob_get_clean();
-	}
-
-	/**
-	* Parses rendered HTML and returns an array of handle groups in document order.
-	*
-	* Each group represents one <link> tag. A concatenated tag will have multiple
-	* handles (e.g., ['a', 'b']), while a regular tag will have one (e.g., ['a']).
-	*/
-	private function extract_handle_groups( string $html ): array {
-		preg_match_all( '/data-handles=["\']([^"\']+)["\']/', $html, $m );
-		$groups = [];
-		foreach ( $m[1] as $list ) {
-			$handles = array_values( array_filter( array_map( 'trim', explode( ',', $list ) ) ) );
-			$groups[] = $handles;
-		}
-		return $groups;
-	}
-
-	private function flatten_groups( array $groups ): array {
-		$out = [];
-		foreach ( $groups as $g ) {
-			foreach ( $g as $h ) {
-				$out[] = $h;
-			}
-		}
-		return $out;
-	}
-
+class Test_CSS_Concat_Order extends CSS_Concat_Test_Case {
 	/**
 	 * When an external/CDN stylesheet appears between two local stylesheets, the concatenation must be split.
 	 *

--- a/tests/test_css_concat_order.php
+++ b/tests/test_css_concat_order.php
@@ -11,6 +11,9 @@ class Test_CSS_Concat_Order extends CSS_Concat_Test_Case {
 	 *
 	 * Enqueue order: a (local) -> b (external CDN) -> c (local)
 	 * Expected output: [a], [b], [c]  (three separate <link> tags)
+	 *
+     * @group css-order-bug
+	 *
 	 **/
 	public function test_nonconcat_item_breaks_concat_run_and_preserves_order(): void {
 		$styles = $this->new_concat_styles();
@@ -37,6 +40,9 @@ class Test_CSS_Concat_Order extends CSS_Concat_Test_Case {
 	 *
 	 * Enqueue order: a (media="all") -> b (media="screen") -> c (media="all")
 	 * Expected output order: a, b, c (not a+c combined, then b)
+	 *
+     * @group css-order-bug
+	 *
 	 **/
 	public function test_media_interleaving_must_not_reorder_handles(): void {
 		$styles = $this->new_concat_styles();
@@ -67,6 +73,9 @@ class Test_CSS_Concat_Order extends CSS_Concat_Test_Case {
 	 *
 	 * Enqueue: a (with inline style after it) -> b
 	 * Expected output: [a], [b]  (two separate tags, not combined)
+	 *
+     * @group css-order-bug
+	 *
 	 **/
 	public function test_inline_style_should_break_concat_boundary(): void {
 		$styles = $this->new_concat_styles();
@@ -77,7 +86,7 @@ class Test_CSS_Concat_Order extends CSS_Concat_Test_Case {
 		$styles->add( 'a', $a, [], null, 'all' );
 		$styles->add( 'b', $b, [], null, 'all' );
 
-		// Inline CSS on "a" must not be moved after "b"’s rules due to concatenation.
+		// Inline CSS on "a" must not be moved after "b"'s rules due to concatenation.
 		$styles->add_inline_style( 'a', '.po-inline-a{color:red;}' );
 
 		$styles->enqueue( 'a' );

--- a/tests/test_css_concat_order.php
+++ b/tests/test_css_concat_order.php
@@ -12,7 +12,7 @@ class Test_CSS_Concat_Order extends CSS_Concat_Test_Case {
 	 * Enqueue order: a (local) -> b (external CDN) -> c (local)
 	 * Expected output: [a], [b], [c]  (three separate <link> tags)
 	 *
-     * @group css-order-bug
+	 * @group css-order-bug
 	 *
 	 **/
 	public function test_nonconcat_item_breaks_concat_run_and_preserves_order(): void {
@@ -41,7 +41,7 @@ class Test_CSS_Concat_Order extends CSS_Concat_Test_Case {
 	 * Enqueue order: a (media="all") -> b (media="screen") -> c (media="all")
 	 * Expected output order: a, b, c (not a+c combined, then b)
 	 *
-     * @group css-order-bug
+	 * @group css-order-bug
 	 *
 	 **/
 	public function test_media_interleaving_must_not_reorder_handles(): void {
@@ -74,7 +74,7 @@ class Test_CSS_Concat_Order extends CSS_Concat_Test_Case {
 	 * Enqueue: a (with inline style after it) -> b
 	 * Expected output: [a], [b]  (two separate tags, not combined)
 	 *
-     * @group css-order-bug
+	 * @group css-order-bug
 	 *
 	 **/
 	public function test_inline_style_should_break_concat_boundary(): void {

--- a/tests/test_css_concat_order.php
+++ b/tests/test_css_concat_order.php
@@ -1,0 +1,192 @@
+<?php
+// tests/test_css_concat_order.php
+
+/**
+ * @group page-optimize
+ */
+class Test_CSS_Concat_Order extends WP_UnitTestCase {
+	private $tmp_files = [];
+
+	public function set_up(): void {
+		parent::set_up();
+
+		require_once dirname( __DIR__ ) . '/concat-css.php';
+
+		add_filter( 'page_optimize_style_loader_tag', [ $this, 'inject_data_handles_into_page_optimize_tag' ], 10, 4 );
+		add_filter( 'style_loader_tag', [ $this, 'inject_data_handles_into_core_tag' ], 10, 4 );
+	}
+
+	public function tear_down(): void {
+		remove_filter( 'page_optimize_style_loader_tag', [ $this, 'inject_data_handles_into_page_optimize_tag' ], 10 );
+		remove_filter( 'style_loader_tag', [ $this, 'inject_data_handles_into_core_tag' ], 10 );
+
+		foreach ( $this->tmp_files as $file ) {
+			@unlink( $file );
+		}
+		$this->tmp_files = [];
+
+		parent::tear_down();
+	}
+
+	public function inject_data_handles_into_page_optimize_tag( $tag, $handles, $href, $media ) {
+		$list = is_array( $handles ) ? implode( ',', $handles ) : (string) $handles;
+
+		if ( false === strpos( $tag, 'data-handles=' ) ) {
+			$tag = preg_replace(
+				'/<link\s/i',
+				'<link data-handles="' . esc_attr( $list ) . '" ',
+				$tag,
+				1
+			);
+		}
+		return $tag;
+	}
+
+	public function inject_data_handles_into_core_tag( $tag, $handle, $href, $media ) {
+		if ( false === strpos( $tag, 'data-handles=' ) ) {
+			$tag = preg_replace(
+				'/<link\s/i',
+				'<link data-handles="' . esc_attr( $handle ) . '" ',
+				$tag,
+				1
+			);
+		}
+		return $tag;
+	}
+
+	private function make_content_css( string $filename, string $contents = '/* test */' ): string {
+		$fs = trailingslashit( WP_CONTENT_DIR ) . $filename;
+		$result = file_put_contents( $fs, $contents );
+		$this->assertNotFalse( $result, 'Failed to write temporary CSS fixture.' );
+		$this->tmp_files[] = $fs;
+
+		return content_url( $filename );
+	}
+
+	private function new_concat_styles(): Page_Optimize_CSS_Concat {
+		$core = new WP_Styles();
+		$core->base_url = untrailingslashit( site_url() );
+
+		$concat = new Page_Optimize_CSS_Concat( $core );
+		// Disable compression so URLs remain human-readable in test output.
+		$concat->allow_gzip_compression = false;
+
+		return $concat;
+	}
+
+	private function render( WP_Styles $styles ): string {
+		ob_start();
+		$styles->do_items();
+		return (string) ob_get_clean();
+	}
+
+	/**
+	* Parses rendered HTML and returns an array of handle groups in document order.
+	*
+	* Each group represents one <link> tag. A concatenated tag will have multiple
+	* handles (e.g., ['a', 'b']), while a regular tag will have one (e.g., ['a']).
+	*/
+	private function extract_handle_groups( string $html ): array {
+		preg_match_all( '/data-handles=["\']([^"\']+)["\']/', $html, $m );
+		$groups = [];
+		foreach ( $m[1] as $list ) {
+			$handles = array_values( array_filter( array_map( 'trim', explode( ',', $list ) ) ) );
+			$groups[] = $handles;
+		}
+		return $groups;
+	}
+
+	private function flatten_groups( array $groups ): array {
+		$out = [];
+		foreach ( $groups as $g ) {
+			foreach ( $g as $h ) {
+				$out[] = $h;
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 * When an external/CDN stylesheet appears between two local stylesheets, the concatenation must be split.
+	 *
+	 * Enqueue order: a (local) -> b (external CDN) -> c (local)
+	 * Expected output: [a], [b], [c]  (three separate <link> tags)
+	 **/
+	public function test_nonconcat_item_breaks_concat_run_and_preserves_order(): void {
+		$styles = $this->new_concat_styles();
+
+		$a = $this->make_content_css( 'po-a.css' );
+		$c = $this->make_content_css( 'po-c.css' );
+
+		$styles->add( 'a', $a, [], null, 'all' );
+		$styles->add( 'b', 'https://cdn.example.invalid/b.css', [], null, 'all' ); // External URL - can't be concatted
+		$styles->add( 'c', $c, [], null, 'all' );
+
+		$styles->enqueue( 'a' );
+		$styles->enqueue( 'b' );
+		$styles->enqueue( 'c' );
+
+		$html   = $this->render( $styles );
+		$groups = $this->extract_handle_groups( $html );
+
+		$this->assertSame( [ [ 'a' ], [ 'b' ], [ 'c' ] ], $groups, 'Expected external stylesheet to break concat and keep order.' );
+	}
+
+	/**
+	 * When stylesheets have different media attributes, concatenation must respect the original order.
+	 *
+	 * Enqueue order: a (media="all") -> b (media="screen") -> c (media="all")
+	 * Expected output order: a, b, c (not a+c combined, then b)
+	 **/
+	public function test_media_interleaving_must_not_reorder_handles(): void {
+		$styles = $this->new_concat_styles();
+
+		$a = $this->make_content_css( 'po-ma.css' );
+		$b = $this->make_content_css( 'po-mb.css' );
+		$c = $this->make_content_css( 'po-mc.css' );
+
+		$styles->add( 'a', $a, [], null, 'all' );
+		$styles->add( 'b', $b, [], null, 'screen' );
+		$styles->add( 'c', $c, [], null, 'all' );
+
+		$styles->enqueue( 'a' );
+		$styles->enqueue( 'b' );
+		$styles->enqueue( 'c' );
+
+		$html    = $this->render( $styles );
+		$groups  = $this->extract_handle_groups( $html );
+		$handles = $this->flatten_groups( $groups );
+
+		// Handles must appear in the same order they were enqueued.
+		$this->assertSame( [ 'a', 'b', 'c' ], $handles, 'Media interleaving should not cause reordering (split concat runs on media changes).' );
+	}
+
+	/**
+	 * When a stylesheet has inline CSS added via add_inline_style(), it can't be concatenated with
+	 * subsequent stylesheets.
+	 *
+	 * Enqueue: a (with inline style after it) -> b
+	 * Expected output: [a], [b]  (two separate tags, not combined)
+	 **/
+	public function test_inline_style_should_break_concat_boundary(): void {
+		$styles = $this->new_concat_styles();
+
+		$a = $this->make_content_css( 'po-ia.css' );
+		$b = $this->make_content_css( 'po-ib.css' );
+
+		$styles->add( 'a', $a, [], null, 'all' );
+		$styles->add( 'b', $b, [], null, 'all' );
+
+		// Inline CSS on "a" must not be moved after "b"’s rules due to concatenation.
+		$styles->add_inline_style( 'a', '.po-inline-a{color:red;}' );
+
+		$styles->enqueue( 'a' );
+		$styles->enqueue( 'b' );
+
+		$html   = $this->render( $styles );
+		$groups = $this->extract_handle_groups( $html );
+
+		// "a" and "b" must not be in the same concatenated <link>.
+		$this->assertSame( [ [ 'a' ], [ 'b' ] ], $groups, 'Inline CSS should force a boundary (do not concat across inline styles).' );
+	}
+}


### PR DESCRIPTION
Run locally with
```
docker compose up --build --abort-on-container-exit --exit-code-from tests
```

These are the failing tests describing currently failing behavior:

:x: **test_nonconcat_item_breaks_concat_run_and_preserves_order**
When an external/CDN stylesheet appears between two local stylesheets, the concatenation must be split.
Enqueue order: a (local) -> b (external CDN) -> c (local)
Expected output: [a], [b], [c]  (three separate <link> tags)

:x: **test_media_interleaving_must_not_reorder_handles**
When stylesheets have different media attributes, concatenation must respect the original order.
Enqueue order: a (media="all") -> b (media="screen") -> c (media="all")
Expected output order: a, b, c (not a+c combined, then b)

:x: **test_inline_style_should_break_concat_boundary**
When a stylesheet has inline CSS added via add_inline_style(), it can't be concatenated with subsequent stylesheets.
Enqueue: a (with inline style after it) -> b
Expected output: [a], [b]  (two separate tags, not combined)

They are tagged with `@group css-order-bug` so we can still get the green check if everything else passes.

I hope that we can fix these bugs and remove this division soon.