### PR TITLE
Add more tests and test updates

### DIFF
--- a/tests/class-js-concat-test-case.php
+++ b/tests/class-js-concat-test-case.php
@@ -1,0 +1,110 @@
+<?php
+
+abstract class JS_Concat_Test_Case extends WP_UnitTestCase {
+	protected $tmp_files = [];
+	protected $did_items = null;
+
+	public function set_up(): void {
+		parent::set_up();
+		require_once dirname( __DIR__ ) . '/concat-js.php';
+
+		add_action( 'js_concat_did_items', [ $this, 'capture_did_items' ], 10, 1 );
+	}
+
+	public function tear_down(): void {
+		remove_action( 'js_concat_did_items', [ $this, 'capture_did_items' ], 10 );
+
+		foreach ( $this->tmp_files as $file ) {
+			@unlink( $file );
+		}
+		$this->tmp_files = [];
+
+		parent::tear_down();
+	}
+
+	public function capture_did_items( $items ): void {
+		$this->did_items = $items;
+	}
+
+	protected function make_content_js( string $filename, string $contents = 'console.log("test");' ): string {
+		$fs = trailingslashit( WP_CONTENT_DIR ) . $filename;
+		$result = file_put_contents( $fs, $contents );
+		$this->assertNotFalse( $result, 'Failed to write temporary JS fixture.' );
+		$this->tmp_files[] = $fs;
+
+		return content_url( $filename );
+	}
+
+	protected function new_concat_scripts(): Page_Optimize_JS_Concat {
+		$core           = new WP_Scripts();
+		$core->base_url = untrailingslashit( site_url() );
+
+		$concat = new Page_Optimize_JS_Concat( $core );
+		$concat->allow_gzip_compression = false;
+
+		return $concat;
+	}
+
+	protected function render( WP_Scripts $scripts, $group = false ): string {
+		$this->did_items = null;
+		ob_start();
+		$scripts->do_items( false, $group );
+		return (string) ob_get_clean();
+	}
+
+	protected function render_head( WP_Scripts $scripts ): string {
+		$this->did_items = null;
+		ob_start();
+		$scripts->do_items( false, 0 ); // head pass
+		return (string) ob_get_clean();
+	}
+
+	protected function render_footer( WP_Scripts $scripts ): string {
+		$this->did_items = null;
+		ob_start();
+
+		// This matches core behavior: footer pass processes only what head collected.
+		if ( method_exists( $scripts, 'do_footer_items' ) ) {
+			$scripts->do_footer_items();
+		} else {
+			$scripts->do_items( $scripts->in_footer, 1 );
+		}
+
+		return (string) ob_get_clean();
+	}
+
+	protected function render_head_groups( WP_Scripts $scripts ): array {
+		$h = $this->render_head( $scripts );
+		return $this->extract_handle_groups_from_did_items();
+	}
+
+	protected function render_footer_groups( WP_Scripts $scripts ): array {
+		$this->render_footer( $scripts );
+		return $this->extract_handle_groups_from_did_items();
+	}
+
+	protected function extract_handle_groups_from_did_items(): array {
+		$this->assertNotNull( $this->did_items, 'Expected js_concat_did_items to fire and capture items.' );
+
+		$groups = [];
+		foreach ( $this->did_items as $item ) {
+			if ( ( $item['type'] ?? null ) === 'concat' ) {
+				$groups[] = $item['handles'] ?? [];
+			} elseif ( ( $item['type'] ?? null ) === 'do_item' ) {
+				$groups[] = [ $item['handle'] ];
+			}
+		}
+		return $groups;
+	}
+
+	protected function flatten_groups( array $groups ): array {
+		$out = [];
+		foreach ( $groups as $g ) {
+			foreach ( $g as $h ) {
+				$out[] = $h;
+			}
+		}
+		return $out;
+	}
+}
+

--- a/tests/test_css_concat_eligibility.php
+++ b/tests/test_css_concat_eligibility.php
@@ -53,39 +53,6 @@ class Test_CSS_Concat_Eligibility extends CSS_Concat_Test_Case {
 	}
 
 	/**
-	* Stylesheets wrapped in IE conditional comments (e.g., <!--[if lt IE 9]>)
-	* cannot be concatenated.
-	*
-	* Conditional comments are HTML-level constructs that wrap the entire <link> tag.
-	* You can't concatenate a conditional stylesheet with a non-conditional one - the
-	* conditional wrapper would incorrectly apply to both.
-	*/
-	public function test_conditional_styles_are_not_concatenated(): void {
-		$styles = $this->new_concat_styles();
-
-		$a = $this->make_content_css( 'po-cond-a.css' );
-		$b = $this->make_content_css( 'po-cond-b.css' );
-
-		$styles->add( 'a', $a, [], null, 'all' );
-		$styles->add( 'b', $b, [], null, 'all' );
-
-		// Mark b as conditional (IE, etc.) - should not be concatenated.
-		$styles->registered['b']->extra['conditional'] = 'lt IE 9';
-
-		$styles->enqueue( 'a' );
-		$styles->enqueue( 'b' );
-
-		$html   = $this->render( $styles );
-		$groups = $this->extract_handle_groups( $html );
-
-		foreach ( $groups as $g ) {
-			if ( in_array( 'b', $g, true ) ) {
-				$this->assertCount( 1, $g, 'Conditional stylesheet should never be concatenated with others.' );
-			}
-		}
-	}
-
-	/**
 	* When the page is in RTL (right-to-left) mode and a stylesheet has RTL-specific
 	* handling, it cannot be concatenated.
 	*

--- a/tests/test_css_concat_order.php
+++ b/tests/test_css_concat_order.php
@@ -104,6 +104,7 @@ class Test_CSS_Concat_Order extends CSS_Concat_Test_Case {
 	 *
 	 * Enqueue: a (with inline style after it) -> b
 	 * Expected output: [a], [b]  (two separate tags, not combined)
+	 * Expected output: Inline should appear before b stylesheet.
 	 *
 	 * @group css-order-bug
 	 *

--- a/tests/test_js_concat_eligibility.php
+++ b/tests/test_js_concat_eligibility.php
@@ -1,0 +1,233 @@
+<?php
+
+require_once __DIR__ . '/class-js-concat-test-case.php';
+
+/**
+ * Tests for JavaScript concatenation eligibility and boundary conditions.
+ *
+ * These tests verify that the Page_Optimize_JS_Concat class correctly determines
+ * which scripts can be concatenated together and properly handles cases where
+ * concatenation must be disabled or split.
+ */
+class Test_JS_Concat_Eligibility extends JS_Concat_Test_Case {
+
+	/**
+	 * Verifies the basic success case: two local scripts should be combined
+	 * into a single concatenated <script> tag.
+	 *
+	 * Also verifies the concatenated URL uses the /_static/?? combo endpoint
+	 * (the server-side mechanism that serves multiple files in one request).
+	 */
+	public function test_concats_two_internal_scripts_into_one_group(): void {
+		$scripts = $this->new_concat_scripts();
+
+		$a = $this->make_content_js( 'po-a.js' );
+		$b = $this->make_content_js( 'po-b.js' );
+
+		$scripts->add( 'a', $a, [], null, false );
+		$scripts->add( 'b', $b, [], null, false );
+
+		$scripts->enqueue( 'a' );
+		$scripts->enqueue( 'b' );
+
+		$html   = $this->render( $scripts );
+		$groups = $this->extract_handle_groups_from_did_items();
+
+		$this->assertSame( [ [ 'a', 'b' ] ], $groups );
+		$this->assertStringContainsString( '/_static/??', $html );
+	}
+
+	/**
+	 * When an external/CDN script appears between two local scripts, the
+	 * concatenation must be split to preserve execution order.
+	 *
+	 * Enqueue order: a (local) -> b (external CDN) -> c (local)
+	 * Expected output: [a], [b], [c]  (three separate <script> tags)
+	 *
+	 * This also detects accidental "pull all concat-eligible into one bucket"
+	 * behavior-if a and c were grouped together, b would execute after both.
+	 */
+	public function test_external_script_breaks_concat_run_and_preserves_order(): void {
+		$scripts = $this->new_concat_scripts();
+
+		$a = $this->make_content_js( 'po-a2.js' );
+		$c = $this->make_content_js( 'po-c2.js' );
+
+		$scripts->add( 'a', $a, [], null, false );
+		$scripts->add( 'b', 'https://cdn.example.invalid/b.js', [], null, false );
+		$scripts->add( 'c', $c, [], null, false );
+
+		$scripts->enqueue( 'a' );
+		$scripts->enqueue( 'b' );
+		$scripts->enqueue( 'c' );
+
+		$this->render( $scripts );
+		$groups = $this->extract_handle_groups_from_did_items();
+
+		$this->assertSame( [ [ 'a' ], [ 'b' ], [ 'c' ] ], $groups );
+	}
+
+	/**
+	 * When a script has inline JavaScript added via add_inline_script(), it
+	 * cannot be concatenated with subsequent scripts.
+	 *
+	 * WordPress's add_inline_script() injects code immediately before/after
+	 * the <script> tag. If scripts were concatenated, the inline code would
+	 * execute at the wrong time relative to other scripts.
+	 */
+	public function test_inline_script_breaks_concat_boundary(): void {
+		$scripts = $this->new_concat_scripts();
+
+		$a = $this->make_content_js( 'po-ia.js' );
+		$b = $this->make_content_js( 'po-ib.js' );
+
+		$scripts->add( 'a', $a, [], null, false );
+		$scripts->add( 'b', $b, [], null, false );
+
+		$scripts->add_inline_script( 'a', 'window.__po_inline_a = true;', 'after' );
+
+		$scripts->enqueue( 'a' );
+		$scripts->enqueue( 'b' );
+
+		$this->render( $scripts );
+		$groups = $this->extract_handle_groups_from_did_items();
+
+		$this->assertSame( [ [ 'a' ], [ 'b' ] ], $groups );
+	}
+
+	/**
+	 * Files starting with "use strict"; cannot be safely concatenated.
+	 *
+	 * JavaScript's strict mode directive only applies to the file/function scope
+	 * it appears in. When scripts are concatenated, a "use strict" at the top of
+	 * one file would incorrectly apply strict mode to all preceding concatenated
+	 * code, potentially breaking scripts that rely on non-strict behavior.
+	 *
+	 * This is a classic "looks safe but isn't" rule that's easy to regress.
+	 */
+	public function test_strict_mode_file_is_not_concatenated(): void {
+		$scripts = $this->new_concat_scripts();
+
+		$a = $this->make_content_js( 'po-sa.js', "console.log('a');" );
+		$b = $this->make_content_js( 'po-sb.js', "'use strict';\nconsole.log('b');" );
+		$c = $this->make_content_js( 'po-sc.js', "console.log('c');" );
+
+		$scripts->add( 'a', $a, [], null, false );
+		$scripts->add( 'b', $b, [], null, false );
+		$scripts->add( 'c', $c, [], null, false );
+
+		$scripts->enqueue( 'a' );
+		$scripts->enqueue( 'b' );
+		$scripts->enqueue( 'c' );
+
+		$this->render( $scripts );
+		$groups = $this->extract_handle_groups_from_did_items();
+
+		$this->assertSame( [ [ 'a' ], [ 'b' ], [ 'c' ] ], $groups );
+	}
+
+	/**
+	* Handles in the exclusion list are not concatenated, even if they
+	* point to local files that would otherwise be eligible.
+	*/
+	public function test_exclusion_list_prevents_concatenation_of_handle(): void {
+		$old = get_option( 'page_optimize-js-exclude', null );
+		update_option( 'page_optimize-js-exclude', 'a' );
+
+		try {
+			$scripts = $this->new_concat_scripts();
+
+			$a = $this->make_content_js( 'po-ex-a.js' );
+			$b = $this->make_content_js( 'po-ex-b.js' );
+
+			$scripts->add( 'a', $a, [], null, false );
+			$scripts->add( 'b', $b, [], null, false );
+
+			$scripts->enqueue( 'a' );
+			$scripts->enqueue( 'b' );
+
+			$this->render( $scripts );
+			$groups = $this->extract_handle_groups_from_did_items();
+
+			$this->assertSame( [ [ 'a' ], [ 'b' ] ], $groups );
+		} finally {
+			if ( null === $old ) {
+				delete_option( 'page_optimize-js-exclude' );
+			} else {
+				update_option( 'page_optimize-js-exclude', $old );
+			}
+		}
+	}
+
+	/**
+	* When the page_optimize-load-mode option is set to 'async', concatenated
+	* script tags should include the async attribute.
+	*
+	* Async/defer loading changes script execution timing, which can cause
+	* subtle breakage if the attribute is missing or incorrectly applied.
+	**/
+	public function test_load_mode_async_is_added_to_concat_script_tag(): void {
+		$old = get_option( 'page_optimize-load-mode', null );
+		update_option( 'page_optimize-load-mode', 'async' );
+
+		try {
+			$scripts = $this->new_concat_scripts();
+
+			$a = $this->make_content_js( 'po-la.js' );
+			$b = $this->make_content_js( 'po-lb.js' );
+
+			$scripts->add( 'a', $a, [], null, false );
+			$scripts->add( 'b', $b, [], null, false );
+
+			$scripts->enqueue( 'a' );
+			$scripts->enqueue( 'b' );
+
+			$html = $this->render( $scripts );
+
+			$this->assertStringContainsString( ' async', $html );
+		} finally {
+			if ( null === $old ) {
+				delete_option( 'page_optimize-load-mode' );
+			} else {
+				update_option( 'page_optimize-load-mode', $old );
+			}
+		}
+	}
+
+	/**
+	* Invalid load mode values should be sanitized to an empty string.
+	*
+	* This ensures the sanitizer is actually being called in the render path
+	* and protects against unexpected output if the option contains garbage.
+	*/
+	public function test_invalid_load_mode_is_sanitized_and_not_rendered(): void {
+		$old = get_option( 'page_optimize-load-mode', null );
+		update_option( 'page_optimize-load-mode', 'not-a-real-mode' );
+
+		try {
+			$scripts = $this->new_concat_scripts();
+
+			$a = $this->make_content_js( 'po-san-a.js' );
+			$b = $this->make_content_js( 'po-san-b.js' );
+
+			$scripts->add( 'a', $a, [], null, false );
+			$scripts->add( 'b', $b, [], null, false );
+
+			$scripts->enqueue( 'a' );
+			$scripts->enqueue( 'b' );
+
+			$html = $this->render( $scripts );
+
+			$this->assertStringNotContainsString( 'not-a-real-mode', $html );
+			// Also verify neither async nor defer appear (since the sanitized value is empty).
+			$this->assertStringNotContainsString( ' async', $html );
+			$this->assertStringNotContainsString( ' defer', $html );
+		} finally {
+			if ( null === $old ) {
+				delete_option( 'page_optimize-load-mode' );
+			} else {
+				update_option( 'page_optimize-load-mode', $old );
+			}
+		}
+	}
+}

--- a/tests/test_js_concat_order.php
+++ b/tests/test_js_concat_order.php
@@ -1,0 +1,121 @@
+<?php
+
+require_once __DIR__ . '/class-js-concat-test-case.php';
+
+/**
+ * Tests for JavaScript concatenation ordering and grouping boundaries.
+ *
+ * Verify that the Page_Optimize_JS_Concat class preserves script
+ * execution order and respects head/footer boundaries during concatenation.
+ *
+ */
+class Test_JS_Concat_Order extends JS_Concat_Test_Case {
+	public function test_head_and_footer_scripts_are_not_concatenated_together(): void {
+		$scripts = $this->new_concat_scripts();
+
+		$a = $this->make_content_js( 'po-head-a.js' );
+		$b = $this->make_content_js( 'po-footer-b.js' );
+
+		$scripts->add( 'a', $a, [], null, false );
+		$scripts->add( 'b', $b, [], null, true );
+		$scripts->add_data( 'b', 'group', 1 ); // Manually set "footer"
+
+		$scripts->enqueue( 'a' );
+		$scripts->enqueue( 'b' );
+
+		$head_groups = $this->render_head_groups( $scripts );
+
+		// Footer script should NOT appear in head did_items at all.
+		$this->assertSame( [ [ 'a' ] ], $head_groups );
+		$this->assertContains( 'b', $scripts->in_footer, 'Footer script should be collected into in_footer during head pass.' );
+
+		$footer_groups = $this->render_footer_groups( $scripts );
+		$this->assertSame( [ [ 'b' ] ], $footer_groups );
+	}
+
+	public function test_multiple_head_scripts_are_concatenated(): void {
+		$scripts = $this->new_concat_scripts();
+
+		$a = $this->make_content_js( 'po-head-a2.js' );
+		$b = $this->make_content_js( 'po-head-b2.js' );
+
+		$scripts->add( 'a', $a, [], null, false );
+		$scripts->add( 'b', $b, [], null, false );
+
+		$scripts->enqueue( 'a' );
+		$scripts->enqueue( 'b' );
+
+		$head_groups = $this->render_head_groups( $scripts );
+		$this->assertSame( [ [ 'a', 'b' ] ], $head_groups );
+	}
+
+	public function test_multiple_footer_scripts_are_concatenated(): void {
+		$scripts = $this->new_concat_scripts();
+
+		$a = $this->make_content_js( 'po-footer-a3.js' );
+		$b = $this->make_content_js( 'po-footer-b3.js' );
+
+		$scripts->add( 'a', $a, [], null, true );
+		$scripts->add( 'b', $b, [], null, true );
+		$scripts->add_data( 'a', 'group', 1 ); // Manually set "footer"
+		$scripts->add_data( 'b', 'group', 1 ); // Manually set "footer"
+
+		$scripts->enqueue( 'a' );
+		$scripts->enqueue( 'b' );
+
+		// Must run head pass first so footer handles get collected.
+		$this->render_head( $scripts );
+
+		$footer_groups = $this->render_footer_groups( $scripts );
+		$this->assertSame( [ [ 'a', 'b' ] ], $footer_groups );
+	}
+
+	public function test_mixed_head_and_footer_scripts_concatenate_within_groups(): void {
+		$scripts = $this->new_concat_scripts();
+
+		$a = $this->make_content_js( 'po-mix-a.js' );
+		$b = $this->make_content_js( 'po-mix-b.js' );
+		$c = $this->make_content_js( 'po-mix-c.js' );
+		$d = $this->make_content_js( 'po-mix-d.js' );
+
+		$scripts->add( 'a', $a, [], null, false );
+		$scripts->add( 'b', $b, [], null, true );
+		$scripts->add_data( 'b', 'group', 1 ); // Manually set "footer"
+		$scripts->add( 'c', $c, [], null, false );
+		$scripts->add( 'd', $d, [], null, true );
+		$scripts->add_data( 'd', 'group', 1 ); // Manually set "footer"
+
+		$scripts->enqueue( 'a' );
+		$scripts->enqueue( 'b' );
+		$scripts->enqueue( 'c' );
+		$scripts->enqueue( 'd' );
+
+		$head_groups = $this->render_head_groups( $scripts );
+		$this->assertSame( [ [ 'a', 'c' ] ], $head_groups );
+
+		$footer_groups = $this->render_footer_groups( $scripts );
+		$this->assertSame( [ [ 'b', 'd' ] ], $footer_groups );
+	}
+
+	public function test_external_footer_script_does_not_break_head_concatenation(): void {
+		$scripts = $this->new_concat_scripts();
+
+		$a = $this->make_content_js( 'po-hf-a.js' );
+		$b = $this->make_content_js( 'po-hf-b.js' );
+
+		$scripts->add( 'a', $a, [], null, false );
+		$scripts->add( 'ext', 'https://cdn.example.invalid/ext.js', [], null, true );
+		$scripts->add_data( 'ext', 'group', 1 ); // Manually set "footer"
+		$scripts->add( 'b', $b, [], null, false );
+
+		$scripts->enqueue( 'a' );
+		$scripts->enqueue( 'ext' );
+		$scripts->enqueue( 'b' );
+
+		$head_groups = $this->render_head_groups( $scripts );
+		$this->assertSame( [ [ 'a', 'b' ] ], $head_groups );
+
+		$footer_groups = $this->render_footer_groups( $scripts );
+		$this->assertSame( [ [ 'ext' ] ], $footer_groups );
+	}
+}


### PR DESCRIPTION
Run tests locally with: `docker compose up --build --abort-on-container-exit --exit-code-from tests`

New changes:

### **Disabling concat should preserve order**
If you enqueue a.css then b.css sheets, but disable concat for a.css, a.css should still come first. Instead, we're seeing a large bundle containing b.css, and then a.css separated but after, which is wrong.

There are two ways to disable - via option and via filter - both of them are falling to this bug. 
`test_exclusion_list_prevents_concatenation_of_handle()` and `test_css_do_concat_filter_can_disable_concatenation()` are updated to check the ordering. They are failing and are also marked with `@group css-order-bug`.


### **Better filter cleanup in `test_css_do_concat_filter_can_disable_concatenation`**
Instead of `remove_all_filters()`, now we just remove the specific filter we added at the end of the test.

### Order test for external first
We currently have a test for a (local) -> b (external cdn) -> c (local), but also added one for a (external CDN) -> b (local) -> c (local). A has to be first.

### Inline test now tests for the inline appearing in the right spot
Before, we were testing: 	 
```
Enqueue: a (with inline style after it) -> b
Expected output: [a], [b]  (two separate tags, not combined)
```
Now an additional criteria is the inline css has to be before B.

### New tests to confirm that concatenation resumes after doing a break
For example, if a (local) -> ext (external) -> b (local) -> c (local), B and C should still be concatted.

## Known failing order bug tests

These are the failing tests describing currently failing behavior:

:x: **test_exclusion_list_prevents_concatenation_of_handle**
Admins can configure specific handles to be excluded from concatenation via the
page_optimize-css-exclude option.
Enqueue order: a (excluded) -> b
Expected output order: [a], [b] (a first, in its own tag)
Bug: [b], [a] (excluded handle pushed to end)

:x: **test_css_do_concat_filter_can_disable_concatenation**
Developers can programmatically exclude handles using the css_do_concat filter hook.
Enqueue order: a (filtered to be excluded) -> b
Expected output order: [a], [b] (a first, in its own tag)
Bug: [b], [a] (excluded handle pushed to end)

:x: **test_nonconcat_item_breaks_concat_run_and_preserves_order**
When an external/CDN stylesheet appears between two local stylesheets, the concatenation must be split.
Enqueue order: a (local) -> b (external CDN) -> c (local)
Expected output: [a], [b], [c]  (three separate <link> tags)

:x: **test_external_stylesheet_first_preserves_order**
When an external/CDN stylesheet is enqueued first, it must remain first in the output.
Enqueue order: a (external CDN) -> b (local) -> c (local)
Expected output: [a], [b, c] or [a], [b], [c]  (a must be first)

:x: **test_media_interleaving_must_not_reorder_handles**
When stylesheets have different media attributes, concatenation must respect the original order.
Enqueue order: a (media="all") -> b (media="screen") -> c (media="all")
Expected output order: a, b, c (not a+c combined, then b)

:x: **test_inline_style_should_break_concat_boundary**
When a stylesheet has inline CSS added via add_inline_style(), it can't be concatenated with subsequent stylesheets.
Enqueue: a (with inline style after it) -> b
Expected output: [a], [b]  (two separate tags, not combined)

:x: **test_concatenation_resumes_after_nonconcat_boundary**
After a non-concatenatable item breaks a run, subsequent local stylesheets
should still be concatenated together.
This catches over-correction where fixing ordering bugs leads to giving up
on concatenation entirely after any boundary.
Enqueue order: a (local) -> ext (external) -> b (local) -> c (local)
Expected: [a], [ext], [b, c]  (order preserved, b+c still concatenated)

:x: **test_same_media_stylesheets_concatenate_within_run**
Stylesheets with the same media attribute should still be concatenated
within their run, even when different media types cause boundaries.
This ensures the fix for media interleaving doesn't accidentally prevent
concatenation within same-media runs.
Enqueue order: a (all) -> b (screen) -> c (screen) -> d (all)
Expected: [a], [b, c], [d]  (order preserved, b+c concatenated)

:x: **test_rtl_stylesheet_breaks_concat_run_and_preserves_order**
a -> b(rtl) -> c

:x: **test_non_static_css_url_breaks_concat_run_and_preserves_order**
a -> b(dynamic - style.php?theme=dark) -> c

They are tagged with `@group css-order-bug` so we can still get the green check if everything else passes.

I hope that we can fix these bugs and remove this division soon.
