### PR TITLE
Fix CSS concat ordering across media and inline boundaries

### DIFF
--- a/concat-css.php
+++ b/concat-css.php
@@ -149,12 +149,13 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 			}
 
 			// Allow plugins to disable concatenation of certain stylesheets.
-			if ( $do_concat && ! apply_filters( 'css_do_concat', $do_concat, $handle ) ) {
+			$filtered_concat = apply_filters( 'css_do_concat', $do_concat, $handle );
+			if ( $do_concat && ! $filtered_concat ) {
 				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 					echo sprintf( "\n<!-- No Concat CSS %s => Filtered `false` -->\n", esc_html( $handle ) );
 				}
 			}
-			$do_concat = apply_filters( 'css_do_concat', $do_concat, $handle );
+			$do_concat = $filtered_concat;
 
 			if ( true === $do_concat ) {
 				$media = $obj->args;

--- a/concat-css.php
+++ b/concat-css.php
@@ -155,7 +155,7 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 				if ( $this->do_item( $css_array['handle'], $group ) ) {
 					$this->done[] = $css_array['handle'];
 				}
-			} elseif ( 'concat' === $css_array['type'] ) {
+			} elseif ( 'concat' === $css_array['type'] && isset( $css_array['paths'] ) ) {
 				// Process each media type within the concat group
 				foreach ( $css_array['paths'] as $media => $css ) {
 					if ( count( $css ) > 1 ) {

--- a/tests/test_css_concat_order.php
+++ b/tests/test_css_concat_order.php
@@ -240,8 +240,8 @@ class Test_CSS_Concat_Order extends CSS_Concat_Test_Case {
 	* need special handling and cannot be concatenated.
 	*
 	* Enqueue order: a (local) -> b (rtl-marked) -> c (local)
-	* Expected output: [a], [b], [c]  (three separate <link> tags, in order)
-	* Bug: [a], [c], [b], [b] ( RTL stylesheet pushed to end, also not sure why there are 2 - test harness issue? )
+	* Expected output: [a], [b], [b], [c]  (two <link> tags for b: base + RTL, in order)
+	* Bug: [a], [c], [b], [b] (RTL stylesheet pushed to end)
 	*
 	* @group css-order-bug
 	*/
@@ -268,10 +268,10 @@ class Test_CSS_Concat_Order extends CSS_Concat_Test_Case {
 		$groups = $this->extract_handle_groups( $html );
 
 		$handles = $this->flatten_groups( $groups );
-		$this->assertSame( [ 'a', 'b', 'c' ], $handles, 'RTL stylesheet must not cause reordering.' );
+		$this->assertSame( [ 'a', 'b', 'b', 'c' ], $handles, 'RTL stylesheet must not cause reordering.' );
 
 		// Each should be in its own group (no concatenation across RTL boundary).
-		$this->assertSame( [ [ 'a' ], [ 'b' ], [ 'c' ] ], $groups, 'RTL stylesheet should break concat run.' );
+		$this->assertSame( [ [ 'a' ], [ 'b' ], [ 'b' ], [ 'c' ] ], $groups, 'RTL stylesheet should break concat run.' );
 	}
 
 	/**


### PR DESCRIPTION
The original version of concat-css.php made a single bucket for concatted CSS, and put everything eligible in there. So if you had [a, b(external cdn), c, d], and B was not eligible, you would have one bucket: [a, c, d] that got concatted, then [b] after. That reorders things.

Now we build sequential "runs" of concats. In the above example, We make an [a], [b], and then a [c, d].  The way it works it is to always build up items in `$concat_group`, but then when we hit a boundary, to `flush` them to the ` $stylesheets = []` array and to clear out `$concat_group`.

In the example above, we'd have:
```php
  $stylesheets = [
    { type: 'concat', paths: [a.css] },
    { type: 'do_item', handle: 'b-external' },
    { type: 'concat', paths: [c.css, d.css] },
  ]

```

The boundaries are external URLs (cdn), dynamic URLs (style.php?mode=dark), RTL, exclusions (specified by option or filter), and inline CSS.

(New) If the "concat group" only contains one handle, we now apply core’s style_loader_tag filter.


### Testing

**Run docker locally:** `docker compose up --build --abort-on-container-exit --exit-code-from tests`

**Real site testing:** 

Add this mu-plugin: 
`wp-content/mu-plugins/po-css-debug-mu-plugin.php`
```php
<?php
/**
 * Plugin Name: PO CSS Order Debug
 * Description: Debug enqueue order and concat boundaries for Page Optimize.
 */

add_action( 'wp_enqueue_scripts', function() {
	if ( ! isset( $_GET['po_css_debug'] ) ) {
		return;
	}

	$upload = wp_upload_dir();
	$dir = trailingslashit( $upload['basedir'] ) . 'po-debug';
	$url = trailingslashit( $upload['baseurl'] ) . 'po-debug';

	if ( ! file_exists( $dir ) ) {
		wp_mkdir_p( $dir );
	}

	$files = [
		'po-a.css'  => '/* a */ .po-a{color:red;}',
		'po-b.css'  => '/* b */ .po-b{color:blue;}',
		'po-c.css'  => '/* c */ .po-c{color:green;}',
		'po-c2.css' => '/* c2 */ .po-c{color:black;}',
		'po-d.css'  => '/* d */ .po-d{color:purple;}',
		'po-e.css'  => '/* e */ .po-d{color:yellow;}',
		'po-f.css'  => '/* f */ .po-d{color:orange;}',
	];

	foreach ( $files as $name => $contents ) {
		$path = $dir . '/' . $name;
		if ( ! file_exists( $path ) ) {
			file_put_contents( $path, $contents );
		}
	}

	// Media interleaving + inline boundary + external + dynamic URL.
	wp_enqueue_style( 'po-a', $url . '/po-a.css', [], null, 'all' );
	wp_add_inline_style( 'po-a', '.po-inline-a{border:1px solid red;}' );

	wp_enqueue_style( 'po-b', 'https://example.com/po-b.css', [], null, 'all' ); // External boundary.

	wp_enqueue_style( 'po-c', $url . '/po-c.css', [], null, 'screen' );
	wp_enqueue_style( 'po-c2', $url . '/po-c2.css', [], null, 'screen' );
	wp_enqueue_style( 'po-d', $url . '/po-d.css', [], null, 'all' );

	wp_enqueue_style( 'po-e', $url . '/po-e.css', [], null, 'all' );
	wp_enqueue_style( 'po-f', $url . '/po-f.css', [], null, 'all' );

	// Non-.css dynamic endpoint boundary.
	wp_enqueue_style( 'po-dyn', home_url( '/?po-debug-css=1' ), [], null, 'all' );
}, 20 );

add_action( 'init', function() {
	if ( isset( $_GET['po-debug-css'] ) ) {
		header( 'Content-Type: text/css; charset=UTF-8' );
		echo '/* dynamic */ .po-dyn{opacity:0.99;}';
		exit;
	}
} );

add_filter( 'page_optimize_style_loader_tag', function( $tag, $handles, $href, $media ) {
	if ( ! isset( $_GET['po_css_debug'] ) ) {
		return $tag;
	}
	$list = is_array( $handles ) ? implode( ',', $handles ) : $handles;
	return $tag . "<!-- po-concat: {$list} | media={$media} | href={$href} -->\n";
}, 100, 4 );

add_filter( 'style_loader_tag', function( $tag, $handle, $href, $media ) {
	if ( ! isset( $_GET['po_css_debug'] ) ) {
		return $tag;
	}
	return $tag . "<!-- po-core: {$handle} | media={$media} | href={$href} -->\n";
}, 100, 4 );
```

Visit `https://example.com/?po_css_debug=1&cachebust=10`

When looking at the source for `po-`, you should expect to see po-a -> po-b -> po-c -> po-c2 -> po-d -> po-e -> po-f -> po-dyn in order.  On the original page optimize, it's not even close. On this version, it's in the correct order and concatted while possible.