### PR TITLE
Page Optimize v0.6.0 release prep

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,31 +14,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Build test image
-        run: docker compose build tests
-      - name: Start DB
-        run: docker compose up -d db
-      - name: Run PHPUnit (excluding known bugs)
+      - name: Run PHPUnit (Docker)
         run: |
-          docker compose run --rm tests bash -lc "bin/run-tests-docker.sh --exclude-group css-order-bug"
-      - name: Run known-bug tests (informational)
-        id: known-bugs
-        run: |
-          set +e
-          docker compose run --rm tests bash -lc "bin/run-tests-docker.sh --group css-order-bug"
-          status=$?
-          echo "status=$status" >> "$GITHUB_OUTPUT"
-          exit 0
-      - name: Report known-bug status
-        if: always()
-        run: |
-          if [ "${{ steps.known-bugs.outputs.status }}" != "0" ]; then
-            echo "::warning::Known CSS order bugs are still failing"
-            echo "⚠️ Known CSS order bugs are still failing." >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "::notice::Known CSS order bugs are now passing—consider removing the group annotation"
-            echo "✅ Known CSS order bugs are now passing — consider removing the group annotation." >> "$GITHUB_STEP_SUMMARY"
-          fi
+          docker compose up --build --abort-on-container-exit --exit-code-from tests
       - name: Cleanup
         if: always()
         run: docker compose down -v

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -4,7 +4,7 @@ Plugin Name: Page Optimize
 Plugin URI: https://wordpress.org/plugins/page-optimize/
 Description: Optimizes JS and CSS for faster page load and render in the browser.
 Author: Automattic
- Version: 0.6.0
+Version: 0.6.0
 Author URI: http://automattic.com/
 */
 

--- a/page-optimize.php
+++ b/page-optimize.php
@@ -4,7 +4,7 @@ Plugin Name: Page Optimize
 Plugin URI: https://wordpress.org/plugins/page-optimize/
 Description: Optimizes JS and CSS for faster page load and render in the browser.
 Author: Automattic
-Version: 0.5.8
+ Version: 0.6.0
 Author URI: http://automattic.com/
 */
 

--- a/readme.txt
+++ b/readme.txt
@@ -78,6 +78,9 @@ Optional overrides (examples):
   have no neighbors to concatenate with (matching the JS-side fix from 0.5.0).
 * Fix: The `css_do_concat` filter was being called twice per handle. It is now
   called once.
+* Fix: CSS concatenation now preserves `@import` and `@charset` rules. A closure
+  scoping bug caused these directives to be stripped from the source but never
+  re-inserted into the output.
 
 = 0.5.8 =
 * Update Tested Up To Version to 6.9.

--- a/readme.txt
+++ b/readme.txt
@@ -73,6 +73,7 @@ Optional overrides (examples):
 * Fix: The css_do_concat filter is now evaluated once per handle.
 * Fix: The concat service no longer drops @import directives due to a closure scoping bug. (@charset/@import handling now runs against the intended pre-output buffer.)
 * Fix: Stylesheets containing @import now start a new concat run so service-side @import hoisting cannot reorder imports ahead of earlier stylesheets.
+* Fix: Treat @import and @charset as case‑insensitive when building concatenated CSS, preventing missed rules in some stylesheets.
 
 = 0.5.8 =
 * Update Tested Up To Version to 6.9.

--- a/readme.txt
+++ b/readme.txt
@@ -67,23 +67,12 @@ Optional overrides (examples):
 == Changelog ==
 
 = 0.6.0 =
-* Fix: CSS concatenation now preserves document order. Previously, all eligible
-  stylesheets were merged into a single group regardless of position, which could
-  reorder them relative to non-concatenated styles (e.g. external or excluded
-	stylesheets). Concatenation now builds sequential runs that break at group
-	boundaries.
-* Fix: Inline styles (`wp_add_inline_style`) now correctly print immediately
-  after their parent stylesheet, even when concatenated.
-* Fix: Apply core's `style_loader_tag` filter for concatenated stylesheets that
-  have no neighbors to concatenate with (matching the JS-side fix from 0.5.0).
-* Fix: The `css_do_concat` filter was being called twice per handle. It is now
-  called once.
-* Fix: CSS concatenation now preserves `@import` and `@charset` rules. A closure
-  scoping bug caused these directives to be stripped from the source but never
-  re-inserted into the output.
-* Fix: Stylesheets containing `@import` now start a new concat group. This
-  prevents the service-side `@import` hoist from reordering rules ahead of
-  earlier stylesheets.
+* Fix: Preserve stylesheet enqueue/document order when concatenating CSS. Concat-eligible styles are now emitted as sequential runs and split around non-concatenated items (e.g. external/excluded/dynamic URLs), media changes, RTL handling, and other boundaries.
+* Fix: Inline styles (wp_add_inline_style) now print immediately after their parent stylesheet, including when styles are concatenated.
+* Fix: Apply core's style_loader_tag filter when a concatenation run contains only a single stylesheet (matching core behavior and the JS-side fix from 0.5.0).
+* Fix: The css_do_concat filter is now evaluated once per handle.
+* Fix: The concat service no longer drops @import directives due to a closure scoping bug. (@charset/@import handling now runs against the intended pre-output buffer.)
+* Fix: Stylesheets containing @import now start a new concat run so service-side @import hoisting cannot reorder imports ahead of earlier stylesheets.
 
 = 0.5.8 =
 * Update Tested Up To Version to 6.9.

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === Page Optimize ===
-Contributors: aidvu, bjorsch, bpayton, rcrdortiz
+Contributors: aidvu, bjorsch, bpayton, mreishus, rcrdortiz
 Tags: performance
 Requires at least: 5.3
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 0.5.8
+Stable tag: 0.6.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -65,6 +65,19 @@ Optional overrides (examples):
 * `PHPUNIT_VERSION=9.6.20 docker compose up --build --abort-on-container-exit --exit-code-from tests`
 
 == Changelog ==
+
+= 0.6.0 =
+* Fix: CSS concatenation now preserves document order. Previously, all eligible
+  stylesheets were merged into a single group regardless of position, which could
+  reorder them relative to non-concatenated styles (e.g. external or excluded
+	stylesheets). Concatenation now builds sequential runs that break at group
+	boundaries.
+* Fix: Inline styles (`wp_add_inline_style`) now correctly print immediately
+  after their parent stylesheet, even when concatenated.
+* Fix: Apply core's `style_loader_tag` filter for concatenated stylesheets that
+  have no neighbors to concatenate with (matching the JS-side fix from 0.5.0).
+* Fix: The `css_do_concat` filter was being called twice per handle. It is now
+  called once.
 
 = 0.5.8 =
 * Update Tested Up To Version to 6.9.

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,9 @@ Optional overrides (examples):
 * Fix: CSS concatenation now preserves `@import` and `@charset` rules. A closure
   scoping bug caused these directives to be stripped from the source but never
   re-inserted into the output.
+* Fix: Stylesheets containing `@import` now start a new concat group. This
+  prevents the service-side `@import` hoist from reordering rules ahead of
+  earlier stylesheets.
 
 = 0.5.8 =
 * Update Tested Up To Version to 6.9.


### PR DESCRIPTION
* Change version to v0.6
* Update Changelog
  * Dev: More tests #91 #92 #93
  * Ordering #94
  * `@import`/`@charset` being dropped #97 #98
  * `@import` breaking order #99 #100 
  * Stray `@charset` #101 #102
  * Allow `@IMPORT` and other case insensitivity #103
* Change github action to run all unit tests, (removing the exception we had for known failing tests that were separated out)