### PR TITLE
Break concat groups when stylesheet contains @import

### DIFF
--- a/concat-css.php
+++ b/concat-css.php
@@ -44,6 +44,51 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 		return false;
 	}
 
+	protected function css_has_import( $path ) {
+		static $cache = array();
+
+		if ( empty( $path ) || ! is_readable( $path ) ) {
+			return false;
+		}
+
+		$key = $path;
+
+		if ( array_key_exists( $key, $cache ) ) {
+			return $cache[ $key ];
+		}
+
+		$fh = @fopen( $path, 'rb' );
+		if ( ! $fh ) {
+			$cache[ $key ] = false;
+			return false;
+		}
+
+		$found = false;
+		$tail  = '';
+
+		// Scan in chunks to keep memory bounded for large stylesheets.
+		while ( ! feof( $fh ) ) {
+			$chunk = fread( $fh, 32768 );
+			if ( false === $chunk || '' === $chunk ) {
+				break;
+			}
+
+			$haystack = $tail . $chunk;
+			if ( false !== stripos( $haystack, '@import' ) ) {
+				$found = true;
+				break;
+			}
+
+			// Keep a short overlap so "@import" across chunk boundaries isn't missed.
+			$tail = substr( $haystack, -7 );
+		}
+
+		fclose( $fh );
+
+		$cache[ $key ] = $found;
+		return $found;
+	}
+
 	function do_items( $handles = false, $group = false ) {
 		$handles = false === $handles ? $this->queue : (array) $handles;
 		$stylesheets = array();
@@ -54,6 +99,7 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 		$concat_group = null;
 
 		foreach ( $this->to_do as $key => $handle ) {
+			$css_realpath = null;
 			// 1a. Skip invalid dependencies.
 			if ( ! isset( $this->registered[ $handle ] ) ) {
 				unset( $this->to_do[ $key ] );
@@ -172,6 +218,7 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 			 * This makes sure output order matches registration order.
 			 **/
 			if ( true === $do_concat ) {
+				$has_import = ! empty( $css_realpath ) && $this->css_has_import( $css_realpath );
 				$media = $obj->args;
 				if ( empty( $media ) ) {
 					$media = 'all';
@@ -179,6 +226,17 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 
 				// Media type changed - finish the current group.
 				if ( null !== $concat_group && $concat_group['media'] !== $media ) {
+					$stylesheets[] = $concat_group;
+					$concat_group = null;
+				}
+
+				// If a non-first stylesheet in a group contains @import, the concat service hoists it,
+				// reordering CSS. Split groups so @import stylesheets are always first in their group.
+				if (
+					null !== $concat_group
+					&& ! empty( $css_realpath )
+					&& $this->css_has_import( $css_realpath )
+				) {
 					$stylesheets[] = $concat_group;
 					$concat_group = null;
 				}

--- a/concat-css.php
+++ b/concat-css.php
@@ -218,7 +218,6 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 			 * This makes sure output order matches registration order.
 			 **/
 			if ( true === $do_concat ) {
-				$has_import = ! empty( $css_realpath ) && $this->css_has_import( $css_realpath );
 				$media = $obj->args;
 				if ( empty( $media ) ) {
 					$media = 'all';

--- a/concat-css.php
+++ b/concat-css.php
@@ -47,7 +47,7 @@ class Page_Optimize_CSS_Concat extends WP_Styles {
 	protected function css_has_import( $path ) {
 		static $cache = array();
 
-		if ( empty( $path ) || ! is_readable( $path ) ) {
+		if ( empty( $path ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
Fixes the CSS ordering bug exposed by the failing tests in #99.

### Problem

The concat service hoists `@import` rules to the top of combined output (required for CSS validity). If a stylesheet with `@import` is concatenated after other stylesheets, its imports jump ahead of earlier rules—breaking cascade order.

### Fix

When building concat groups, if a stylesheet contains `@import` and would *not* be first in the current group, flush the group and start a new one. This ensures `@import` hoisting stays within its intended position in the cascade.

```
Enqueue: a (plain) -> b (@import) -> c (plain)
Before:  [a, b, c] -> @import from b appears before a's rules ✗
After:   [a], [b, c] -> cascade order preserved ✓
```

### Implementation

* stripos - case insensitive
* Doesn't try to remove comments: Regex can mess up on `/*` inside strings, and it's better to add an extra concat group break (slightly less concat benefit) than to accidentally miss an `@import` (break ordering)
* Read the file in chunks: Don't spam memory usage for large files

### Why this approach over alternatives

- **Data-URI wrapping** (`@import url('data:text/css,...')`): This was slower in practice. It can break caching.
- **@import chaining back to concat service**: Turns one request into multiple blocking requests, negating concat's benefit.
- **Inlining imported CSS** Risky with dynamic content and relative URLs, can duplicate content and break caching.

Breaking groups is the simplest fix that preserves correctness without adding extra complexity to the concat service.

### Trade-off

Stylesheets with `@import` will now start new concat groups, which may slightly increase requests. This seems ok since it's better to be correct.