### PR TITLE
Fix misplaced @charset in concat service output

### DIFF
--- a/service.php
+++ b/service.php
@@ -202,7 +202,7 @@ function page_optimize_build_output() {
 
 			// The @charset rules must be on top of the output
 			if ( 0 === strpos( $buf, '@charset' ) ) {
-				preg_replace_callback(
+				$buf = preg_replace_callback(
 					'/(?P<charset_rule>@charset\s+[\'"][^\'"]+[\'"];)/i',
 					function ( $match ) use ( &$pre_output ) {
 


### PR DESCRIPTION
- Ensures @charset rules are removed from the body and moved to the top of the concatenated CSS output.
- Assigns the preg_replace_callback() result back into the buffer so the rule is actually removed after being hoisted.
- Fixes the behavior validated by the new test in #101.
- Redoes the fix in #61.