### PR TITLE
Make @import/@charset detection case‑insensitive in concat service

### DIFF
--- a/service.php
+++ b/service.php
@@ -201,17 +201,16 @@ function page_optimize_build_output() {
 			);
 
 			// The @charset rules must be on top of the output
-			if ( 0 === strpos( $buf, '@charset' ) ) {
+			if ( 0 === stripos( $buf, '@charset' ) ) {
 				$buf = preg_replace_callback(
 					'/(?P<charset_rule>@charset\s+[\'"][^\'"]+[\'"];)/i',
 					function ( $match ) use ( &$pre_output ) {
 
-						if ( 0 === strpos( (string) $pre_output, '@charset' ) ) {
+						if ( 0 === stripos( (string) $pre_output, '@charset' ) ) {
 							return '';
 						}
 
 						$pre_output = $match[0] . "\n" . $pre_output;
-
 						return '';
 					},
 					$buf
@@ -220,12 +219,12 @@ function page_optimize_build_output() {
 
 			// Move the @import rules on top of the concatenated output.
 			// Only @charset rule are allowed before them.
-			if ( false !== strpos( $buf, '@import' ) ) {
+			if ( false !== stripos( $buf, '@import' ) ) {
 				$buf = preg_replace_callback(
 					'/(?P<pre_path>@import\s+(?:url\s*\()?[\'"\s]*)(?P<path>[^\'"\s](?:https?:\/\/.+\/?)?.+?)(?P<post_path>[\'"\s\)]*;)/i',
 					function ( $match ) use ( $dirpath, &$pre_output ) {
 
-						if ( 0 !== strpos( $match['path'], 'http' ) && '/' != $match['path'][0] ) {
+						if ( 0 !== stripos( $match['path'], 'http' ) && '/' != $match['path'][0] ) {
 							$pre_output .= $match['pre_path'] . ( $dirpath == '/' ? '/' : $dirpath . '/' ) .
 										   $match['path'] . $match['post_path'] . "\n";
 						} else {

--- a/tests/test_css_service_imports.php
+++ b/tests/test_css_service_imports.php
@@ -100,4 +100,69 @@ class Test_CSS_Service_Imports extends WP_UnitTestCase {
 		$this->assertSame( 0, strpos( $content, '@charset' ), 'Expected @charset to be the first rule in output.' );
 		$this->assertSame( 1, substr_count( $content, '@charset' ), 'Expected @charset to appear only once in output.' );
 	}
+
+	/**
+	 * The concat service should treat @charset detection as case-insensitive.
+	 */
+	public function test_service_hoists_charset_case_insensitive(): void {
+		$this->make_content_css( 'po-service-charset-ci-a.css', '.po-charset-ci-a{color:red;}' );
+		$this->make_content_css(
+			'po-service-charset-ci-b.css',
+			'@CHARSET "UTF-8";' . "\n" . '.po-charset-ci-b{color:blue;}'
+		);
+
+		$content_path = parse_url( trailingslashit( WP_CONTENT_URL ), PHP_URL_PATH );
+		if ( empty( $content_path ) ) {
+			$content_path = '/wp-content/';
+		}
+		$content_path = trailingslashit( $content_path );
+
+		$uri_a = $content_path . 'po-service-charset-ci-a.css';
+		$uri_b = $content_path . 'po-service-charset-ci-b.css';
+
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+		$_SERVER['REQUEST_URI'] = "/_static/??{$uri_a},{$uri_b}?m=1";
+
+		$output = page_optimize_build_output();
+		$this->assertArrayHasKey( 'content', $output, 'Expected build output to include content.' );
+
+		$content = $output['content'];
+		$this->assertSame( 0, stripos( $content, '@charset' ), 'Expected @charset to be hoisted even when uppercase.' );
+		$this->assertSame( 1, substr_count( strtolower( $content ), '@charset' ), 'Expected @charset to appear only once in output.' );
+	}
+
+	/**
+	 * The concat service should treat @import detection as case-insensitive.
+	 */
+	public function test_service_hoists_import_case_insensitive(): void {
+		$this->make_content_css( 'po-service-import-ci-a.css', '.po-import-ci-a{color:red;}' );
+		$this->make_content_css( 'po-service-import-ci-dep.css', '.po-import-ci-dep{color:blue;}' );
+		$this->make_content_css(
+			'po-service-import-ci-b.css',
+			'@IMPORT "po-service-import-ci-dep.css";' . "\n" . '.po-import-ci-b{color:blue;}'
+		);
+
+		$content_path = parse_url( trailingslashit( WP_CONTENT_URL ), PHP_URL_PATH );
+		if ( empty( $content_path ) ) {
+			$content_path = '/wp-content/';
+		}
+		$content_path = trailingslashit( $content_path );
+
+		$uri_a = $content_path . 'po-service-import-ci-a.css';
+		$uri_b = $content_path . 'po-service-import-ci-b.css';
+
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+		$_SERVER['REQUEST_URI'] = "/_static/??{$uri_a},{$uri_b}?m=1";
+
+		$output = page_optimize_build_output();
+		$this->assertArrayHasKey( 'content', $output, 'Expected build output to include content.' );
+
+		$content = $output['content'];
+		$pos_import = stripos( $content, '@import' );
+		$pos_rule = strpos( $content, '.po-import-ci-a' );
+
+		$this->assertNotFalse( $pos_import, 'Expected @import to be preserved in output.' );
+		$this->assertNotFalse( $pos_rule, 'Expected baseline rule to be present in output.' );
+		$this->assertLessThan( $pos_rule, $pos_import, 'Expected @import to be hoisted above earlier rules even when uppercase.' );
+	}
 }


### PR DESCRIPTION
- Ensures the concat service detects @import and @charset regardless of case, matching the regex behavior and CSS case‑insensitivity.
- Adds tests that fail when detection is case‑sensitive and pass after switching to `stripos()`.