### PR TITLE
Exclude dev/test artifacts from WP.org deploy rsync

### DIFF
--- a/bin/deploy-to-plugin-directory.sh
+++ b/bin/deploy-to-plugin-directory.sh
@@ -102,7 +102,7 @@ fi
 
 # Rsync is faster than cp, and it can handle deleting files in the target
 # directory. We also exclude hidden files so that SVN continues working.
-rsync -a --delete --exclude=".*" --exclude="bin" "$PLUGIN_PATH/" "$TRUNK/"
+rsync -a --delete --exclude=".*" --exclude="bin" --exclude="tests" --exclude="docker-compose.yml" --exclude="Dockerfile.tests" --exclude="phpunit.xml.dist" "$PLUGIN_PATH/" "$TRUNK/"
 
 cd "$TRUNK"
 


### PR DESCRIPTION
  - Updates the deploy script to skip tests and Docker/CI files when syncing to the WP.org SVN trunk.
  - Keeps the plugin zip lean and focused on runtime code only (no test suite or local dev configs).
  - Does not change any runtime behavior.