### PR TITLE
Allow Docker test runs to select PHP version

### DIFF
--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,4 +1,5 @@
-FROM php:8.2-cli
+ARG PHP_VERSION=8.2
+FROM php:${PHP_VERSION}-cli
 
 # System deps for wp-tests + mysql client
 RUN apt-get update \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       context: .
       dockerfile: Dockerfile.tests
       args:
+        PHP_VERSION: ${PHP_VERSION:-8.2}
         PHPUNIT_VERSION: ${PHPUNIT_VERSION:-9.6.20}
     depends_on:
       db:

--- a/readme.txt
+++ b/readme.txt
@@ -62,6 +62,7 @@ Run tests:
 Optional overrides (examples):
 
 * `WP_VERSION=6.5 docker compose up --build --abort-on-container-exit --exit-code-from tests`
+* `PHP_VERSION=7.4 docker compose up --build --abort-on-container-exit --exit-code-from tests`
 * `PHPUNIT_VERSION=9.6.20 docker compose up --build --abort-on-container-exit --exit-code-from tests`
 
 == Changelog ==


### PR DESCRIPTION
- make Docker test image base PHP version configurable via build arg
- pass PHP_VERSION through docker-compose (default 8.2)
- document PHP 7.4 usage example in README