### PR TITLE
Skip JS concatenation for requested defer/async, type="module", and script_loader_tag changed scripts

### DIFF
--- a/concat-js.php
+++ b/concat-js.php
@@ -97,6 +97,8 @@ class Page_Optimize_JS_Concat extends WP_Scripts {
 			$obj = $this->registered[ $handle ];
 			$js_url = $obj->src;
 			$js_url_parsed = parse_url( $js_url );
+			$script_type = strtolower( trim( (string) $this->get_data( $handle, 'type' ) ) );
+			$script_strategy = strtolower( trim( (string) $this->get_data( $handle, 'strategy' ) ) );
 
 			// Don't concat by default
 			$do_concat = false;
@@ -133,6 +135,22 @@ class Page_Optimize_JS_Concat extends WP_Scripts {
 			if ( $do_concat && $this->has_inline_content( $handle ) ) {
 				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 					echo sprintf( "\n<!-- No Concat JS %s => Has Inline Content -->\n", esc_html( $handle ) );
+				}
+				$do_concat = false;
+			}
+
+			// Module scripts are not safe to concatenate with classic scripts.
+			if ( $do_concat && 'module' === $script_type ) {
+				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+					echo sprintf( "\n<!-- No Concat JS %s => Module Script -->\n", esc_html( $handle ) );
+				}
+				$do_concat = false;
+			}
+
+			// Keep requested delayed scripts standalone to avoid strategy eligibility pitfalls.
+			if ( $do_concat && in_array( $script_strategy, array( 'defer', 'async' ), true ) ) {
+				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+					echo sprintf( "\n<!-- No Concat JS %s => Requested Strategy %s -->\n", esc_html( $handle ), esc_html( $script_strategy ) );
 				}
 				$do_concat = false;
 			}

--- a/concat-js.php
+++ b/concat-js.php
@@ -55,6 +55,32 @@ class Page_Optimize_JS_Concat extends WP_Scripts {
 		return false;
 	}
 
+	/**
+	 * Check whether script_loader_tag filters mutate this handle's script tag.
+	 *
+	 * If the tag is mutated, we keep the handle standalone so core can render it.
+	 */
+	protected function script_loader_tag_changes_output( $handle, $js_url ) {
+		if ( ! has_filter( 'script_loader_tag' ) ) {
+			return false;
+		}
+
+		if ( function_exists( 'wp_get_script_tag' ) ) {
+			$probe_tag = wp_get_script_tag(
+				array(
+					'id'  => "{$handle}-js",
+					'src' => $js_url,
+				)
+			);
+		} else {
+			$probe_tag = "<script type='text/javascript' src='" . esc_url( $js_url ) . "'></script>\n";
+		}
+
+		$filtered_tag = apply_filters( 'script_loader_tag', $probe_tag, $handle, $js_url );
+
+		return $filtered_tag !== $probe_tag;
+	}
+
 	function do_items( $handles = false, $group = false ) {
 		$handles = false === $handles ? $this->queue : (array) $handles;
 		$javascripts = array();
@@ -151,6 +177,14 @@ class Page_Optimize_JS_Concat extends WP_Scripts {
 			if ( $do_concat && in_array( $script_strategy, array( 'defer', 'async' ), true ) ) {
 				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 					echo sprintf( "\n<!-- No Concat JS %s => Requested Strategy %s -->\n", esc_html( $handle ), esc_html( $script_strategy ) );
+				}
+				$do_concat = false;
+			}
+
+			// If a script tag is mutated by script_loader_tag, preserve it via core do_item().
+			if ( $do_concat && $this->script_loader_tag_changes_output( $handle, $js_url ) ) {
+				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+					echo sprintf( "\n<!-- No Concat JS %s => script_loader_tag modified -->\n", esc_html( $handle ) );
 				}
 				$do_concat = false;
 			}

--- a/tests/test_js_concat_eligibility.php
+++ b/tests/test_js_concat_eligibility.php
@@ -172,6 +172,25 @@ class Test_JS_Concat_Eligibility extends JS_Concat_Test_Case {
 			[ [ 'a', 'b' ], [ 'c' ], [ 'd' ], [ 'e' ], [ 'f' ], [ 'g' ] ],
 			$groups
 		);
+
+		// Verify that we actually ran the core do_item for the async/defer/module scripts,
+		// instead of printing our own script tag.
+		$types_by_handle = [];
+		foreach ( $this->did_items as $item ) {
+			if ( ( $item['type'] ?? null ) === 'do_item' ) {
+				$types_by_handle[ $item['handle'] ] = 'do_item';
+			}
+			if ( ( $item['type'] ?? null ) === 'concat' ) {
+				foreach ( $item['handles'] as $h ) {
+					$types_by_handle[ $h ] = 'concat';
+				}
+			}
+		}
+
+		$this->assertSame( 'do_item', $types_by_handle['c'] );
+		$this->assertSame( 'do_item', $types_by_handle['d'] );
+		$this->assertSame( 'do_item', $types_by_handle['e'] );
+		$this->assertSame( 'do_item', $types_by_handle['f'] );
 	}
 
 	/**


### PR DESCRIPTION
If a script requests a delayed loading strategy or uses type=module, it's no longer eligible for concat:
- `strategy=defer`
- `strategy=async`
- `type=module`

These scripts will be forced through `do_item()` so WordPress core remains responsible for rendering their final script attributes.

## Why we chose this

WordPress stores `strategy` as an intended value, then computes the actually eligible value at render time. The functions used to do this are private. Re-implementing that eligibility graph inside Page Optimize introduces risk of this drifting from core behavior over time.

### Script_loader_tag

- Handles modified by `script_loader_tag` are not concatenated either.

This also fixes plugins like AmeliaBooking that set `type="module"` with `script_loader_tag` at render time. Concat cannot keep tag rewrites, so if `script_loader_tag` mutates a script’s tag, we force it through `do_item()` to preserve whatever changes were made.

PERFOPS-67
