### PR TITLE
Fix CSS service @import hoisting for long Google Fonts URLs with semicolons

### DIFF
--- a/tests/test_css_service_imports.php
+++ b/tests/test_css_service_imports.php
@@ -72,6 +72,193 @@ class Test_CSS_Service_Imports extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The concat service should not split long @import URLs that contain semicolons.
+	 */
+	public function test_service_preserves_long_google_fonts_import_with_semicolons(): void {
+		$this->make_content_css( 'po-service-import-long-a.css', '.po-import-long-a{color:red;}' );
+		$this->make_content_css(
+			'po-service-import-long-b.css',
+			"@import url('https://fonts.googleapis.com/css2?family=Abel&family=Acme&family=Anonymous+Pro:ital,wght@0,400;0,700;1,400;1,700&family=Archivo+Narrow:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&display=swap');\n" .
+			'.po-import-long-b{color:blue;}'
+		);
+
+		$content_path = parse_url( trailingslashit( WP_CONTENT_URL ), PHP_URL_PATH );
+		if ( empty( $content_path ) ) {
+			$content_path = '/wp-content/';
+		}
+		$content_path = trailingslashit( $content_path );
+
+		$uri_a = $content_path . 'po-service-import-long-a.css';
+		$uri_b = $content_path . 'po-service-import-long-b.css';
+
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+		$_SERVER['REQUEST_URI'] = "/_static/??{$uri_a},{$uri_b}?m=1";
+
+		$output = page_optimize_build_output();
+		$this->assertArrayHasKey( 'content', $output, 'Expected build output to include content.' );
+
+		$content = $output['content'];
+		$this->assertStringContainsString(
+			"@import url('https://fonts.googleapis.com/css2?family=Abel&family=Acme&family=Anonymous+Pro:ital,wght@0,400;0,700;1,400;1,700&family=Archivo+Narrow:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&display=swap');",
+			$content,
+			'Expected long Google Fonts @import to remain intact.'
+		);
+		$this->assertStringNotContainsString(
+			"wght@0,400;\n0,700;",
+			$content,
+			'Expected no newline split at semicolon inside Google Fonts URL.'
+		);
+	}
+
+	/**
+	 * The concat service should not treat "@import" substrings inside URL paths as at-rules.
+	 */
+	public function test_service_does_not_false_positive_import_substring_in_url_path(): void {
+		$this->make_content_css( 'po-service-import-substring-a.css', '.po-import-substring-a{color:red;}' );
+		$this->make_content_css(
+			'po-service-import-substring-b.css',
+			'.po-import-substring-b{background:url(/images/@import.png) no-repeat center;color:blue;}'
+		);
+
+		$content_path = parse_url( trailingslashit( WP_CONTENT_URL ), PHP_URL_PATH );
+		if ( empty( $content_path ) ) {
+			$content_path = '/wp-content/';
+		}
+		$content_path = trailingslashit( $content_path );
+
+		$uri_a = $content_path . 'po-service-import-substring-a.css';
+		$uri_b = $content_path . 'po-service-import-substring-b.css';
+
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+		$_SERVER['REQUEST_URI'] = "/_static/??{$uri_a},{$uri_b}?m=1";
+
+		$output = page_optimize_build_output();
+		$this->assertArrayHasKey( 'content', $output, 'Expected build output to include content.' );
+
+		$content = $output['content'];
+		$this->assertStringContainsString(
+			'.po-import-substring-b{background:url(/images/@import.png) no-repeat center;color:blue;}',
+			$content,
+			'Expected declaration containing @import substring in URL path to remain unchanged.'
+		);
+		$this->assertNotSame(
+			0,
+			stripos( ltrim( $content ), '@import.png' ),
+			'Expected @import substring from URL path not to be hoisted as an @import rule.'
+		);
+	}
+
+	/**
+	 * The concat service should still detect minified @import rules without whitespace.
+	 */
+	public function test_service_hoists_import_without_whitespace_after_keyword(): void {
+		$this->make_content_css( 'po-service-import-nospace-a.css', '.po-import-nospace-a{color:red;}' );
+		$this->make_content_css( 'po-service-import-nospace-dep.css', '.po-import-nospace-dep{color:blue;}' );
+		$this->make_content_css(
+			'po-service-import-nospace-b.css',
+			'@import"po-service-import-nospace-dep.css";.po-import-nospace-b{color:blue;}'
+		);
+
+		$content_path = parse_url( trailingslashit( WP_CONTENT_URL ), PHP_URL_PATH );
+		if ( empty( $content_path ) ) {
+			$content_path = '/wp-content/';
+		}
+		$content_path = trailingslashit( $content_path );
+
+		$uri_a = $content_path . 'po-service-import-nospace-a.css';
+		$uri_b = $content_path . 'po-service-import-nospace-b.css';
+
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+		$_SERVER['REQUEST_URI'] = "/_static/??{$uri_a},{$uri_b}?m=1";
+
+		$output = page_optimize_build_output();
+		$this->assertArrayHasKey( 'content', $output, 'Expected build output to include content.' );
+
+		$content = $output['content'];
+		$expected_dep = '@import"' . $content_path . 'po-service-import-nospace-dep.css";';
+		$this->assertStringContainsString(
+			$expected_dep,
+			$content,
+			'Expected minified @import without whitespace to be detected and rewritten.'
+		);
+		$this->assertStringContainsString( '.po-import-nospace-b{color:blue;}', $content, 'Expected stylesheet body to remain present.' );
+	}
+
+	/**
+	 * The concat service should support comments between @import and the path token.
+	 */
+	public function test_service_hoists_import_with_comment_after_keyword(): void {
+		$this->make_content_css( 'po-service-import-comment-a.css', '.po-import-comment-a{color:red;}' );
+		$this->make_content_css( 'po-service-import-comment-dep.css', '.po-import-comment-dep{color:blue;}' );
+		$this->make_content_css(
+			'po-service-import-comment-b.css',
+			'@import/*keep*/"po-service-import-comment-dep.css";.po-import-comment-b{color:blue;}'
+		);
+
+		$content_path = parse_url( trailingslashit( WP_CONTENT_URL ), PHP_URL_PATH );
+		if ( empty( $content_path ) ) {
+			$content_path = '/wp-content/';
+		}
+		$content_path = trailingslashit( $content_path );
+
+		$uri_a = $content_path . 'po-service-import-comment-a.css';
+		$uri_b = $content_path . 'po-service-import-comment-b.css';
+
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+		$_SERVER['REQUEST_URI'] = "/_static/??{$uri_a},{$uri_b}?m=1";
+
+		$output = page_optimize_build_output();
+		$this->assertArrayHasKey( 'content', $output, 'Expected build output to include content.' );
+
+		$content = $output['content'];
+		$expected_dep = '@import/*keep*/"' . $content_path . 'po-service-import-comment-dep.css";';
+		$this->assertStringContainsString(
+			$expected_dep,
+			$content,
+			'Expected commented @import token to be hoisted and rewritten.'
+		);
+		$this->assertStringContainsString( '.po-import-comment-b{color:blue;}', $content, 'Expected stylesheet body to remain present.' );
+	}
+
+	/**
+	 * The concat service should ignore @import-like tokens inside declaration blocks.
+	 */
+	public function test_service_ignores_import_keyword_inside_rule_body(): void {
+		$this->make_content_css( 'po-service-import-body-a.css', '.po-import-body-a{color:red;}' );
+		$this->make_content_css(
+			'po-service-import-body-b.css',
+			'.po-import-body-b{--po-token:@import "po-fake.css";color:blue;}'
+		);
+
+		$content_path = parse_url( trailingslashit( WP_CONTENT_URL ), PHP_URL_PATH );
+		if ( empty( $content_path ) ) {
+			$content_path = '/wp-content/';
+		}
+		$content_path = trailingslashit( $content_path );
+
+		$uri_a = $content_path . 'po-service-import-body-a.css';
+		$uri_b = $content_path . 'po-service-import-body-b.css';
+
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+		$_SERVER['REQUEST_URI'] = "/_static/??{$uri_a},{$uri_b}?m=1";
+
+		$output = page_optimize_build_output();
+		$this->assertArrayHasKey( 'content', $output, 'Expected build output to include content.' );
+
+		$content = $output['content'];
+		$this->assertStringContainsString(
+			'.po-import-body-b{--po-token:@import "po-fake.css";color:blue;}',
+			$content,
+			'Expected @import-like token inside declaration body to remain untouched.'
+		);
+		$this->assertNotSame(
+			0,
+			stripos( ltrim( $content ), '@import "po-fake.css";' ),
+			'Expected declaration-body token not to be hoisted as top-level @import.'
+		);
+	}
+
+	/**
 	 * The concat service should hoist @charset and remove it from the body output.
 	 */
 	public function test_service_hoists_charset_to_top(): void {


### PR DESCRIPTION
Fixes a CSS concat edge case where long `@import` URLs (for example Google Fonts URLs containing semicolons in `wght` values) were split at the first `;` during service-side import hoisting.

The regex-based hoisting logic in `service.php` has been replaced with parser-style handling that finds the true end of each `@import` rule while respecting quoted strings, comments, and `url(...)` parentheses.

This preserves full import URLs and prevents broken concatenated CSS output.

Includes regression coverage in `tests/test_css_service_imports.php`:
- `test_service_preserves_long_google_fonts_import_with_semicolons`
- `test_service_does_not_false_positive_import_substring_in_url_path`
- `test_service_hoists_import_without_whitespace_after_keyword`

Implemented a character level parser with Codex-5.3 and 5.2 pro.