### PR TITLE
chore: pin third-party GitHub Actions to SHAs + enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,4 +20,3 @@ updates:
           - "major"
     cooldown:
       default-days: 7
-      semver-major-days: 14

--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -31,7 +31,7 @@ jobs:
           node-version: lts/*
 
      - name: Wait for prior instances of the workflow to finish
-       uses: softprops/turnstyle@8db075d65b19bf94e6e8687b504db69938dc3c65 # v1
+       uses: softprops/turnstyle@8db075d65b19bf94e6e8687b504db69938dc3c65 # v0.1.5
        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -31,7 +31,7 @@ jobs:
           node-version: lts/*
 
      - name: Wait for prior instances of the workflow to finish
-       uses: softprops/turnstyle@v1
+       uses: softprops/turnstyle@8db075d65b19bf94e6e8687b504db69938dc3c65 # v0.1.5
        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -31,7 +31,7 @@ jobs:
           node-version: lts/*
 
      - name: Wait for prior instances of the workflow to finish
-       uses: softprops/turnstyle@8db075d65b19bf94e6e8687b504db69938dc3c65 # v0.1.5
+       uses: softprops/turnstyle@8db075d65b19bf94e6e8687b504db69938dc3c65 # v1
        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Two-in-one hardening:

1. Pin third-party GitHub Actions in this repo to commit SHAs (tag preserved as trailing comment).
2. Add Dependabot `github-actions` config (weekly, grouped into `actions-minor-patch` and `actions-major`, with cooldown).

Tracking: DEVPROD-1072.
